### PR TITLE
Fix agent loop races, timer leaks, and UX gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/src/App.css
+++ b/src/App.css
@@ -340,10 +340,14 @@
   50% { opacity: 0.15; transform: scale(1.2); }
 }
 
+/* Thinking — subtle pulse on ring only */
+.status-chip-thinking .status-chip-ring {
+  animation: ringPulse 1.8s ease-in-out infinite;
+}
+
 /* Writing — subtle glow */
 .status-chip-writing {
-  box-shadow: 0 0 0 1px currentColor;
-  animation: chipWriting 1.5s ease-in-out infinite;
+  box-shadow: none;
 }
 
 @keyframes chipWriting {
@@ -733,4 +737,19 @@
 .chat-messages::-webkit-scrollbar-thumb:hover,
 .doc-body::-webkit-scrollbar-thumb:hover {
   background: #bdc1c6;
+}
+
+/* Mobile: stack panels vertically */
+@media (max-width: 640px) {
+  .main-area { flex-direction: column; }
+  .chat-panel.chat-side {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    max-height: 40vh;
+    border-right: none;
+    border-bottom: 1px solid #dadce0;
+  }
+  .doc-panel { min-height: 60vh; }
+  .doc-editor { padding: 24px 16px; }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,11 +76,11 @@ function MessageAvatar({ from, size = 28 }: { from: string, size?: number }) {
 function AgentStatusChip({ name, color, status, inDoc }: {
   name: string, color: string, status: AgentState['status'], inDoc: boolean
 }) {
-  const isVisible = inDoc && (status === 'reading' || status === 'editing' || status === 'typing')
+  const isVisible = inDoc && status !== 'idle'
   if (!isVisible) return null
 
-  const label = status === 'reading' ? 'reading' : 'writing'
-  const statusClass = status === 'reading' ? 'status-chip-reading' : 'status-chip-writing'
+  const label = status === 'reading' ? 'reading' : status === 'thinking' ? 'thinking' : 'writing'
+  const statusClass = status === 'reading' ? 'status-chip-reading' : status === 'thinking' ? 'status-chip-thinking' : 'status-chip-writing'
 
   return (
     <div className={`status-chip ${statusClass}`} style={{ borderColor: color + '50', background: color + '08' }}>

--- a/src/agent-actions.ts
+++ b/src/agent-actions.ts
@@ -9,20 +9,18 @@ const AGENTS: Record<string, { color: string, bgColor: string }> = {
 export interface ActionCallbacks {
   onStateChange: (status: 'idle' | 'thinking' | 'typing' | 'reading' | 'editing', thought?: string) => void
   onChatMessage: (from: string, text: string) => void
-  onDone: () => void
+  onDone: (success?: boolean) => void
 }
 
 // Convert markdown-ish content to standalone HTML blocks for sequential insertion
 function contentToBlocks(content: string): string[] {
-  // Pre-process: normalize ### to ## , strip markdown bold/italic/code
   const cleaned = content
-    .replace(/^#{3,}\s+/gm, '## ')  // ### or #### → ##
-    .replace(/\*\*(.+?)\*\*/g, '$1') // **bold** → plain
-    .replace(/\*(.+?)\*/g, '$1')     // *italic* → plain
-    .replace(/`(.+?)`/g, '$1')       // `code` → plain
+    .replace(/^#{3,}\s+/gm, '## ')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/`(.+?)`/g, '$1')
   const lines = cleaned.split('\n').filter(l => l.trim() !== '')
   const blocks: string[] = []
-  // Track top-level and sub-level list items
   let topItems: { text: string, subItems: string[] }[] = []
 
   const flushList = () => {
@@ -39,13 +37,11 @@ function contentToBlocks(content: string): string[] {
   }
 
   for (const line of lines) {
-    // Indented bullet (2+ spaces or tab before -) → sub-item
     if (/^[\t ]{2,}- /.test(line)) {
       const text = line.replace(/^[\t ]*- /, '')
       if (topItems.length > 0) {
         topItems[topItems.length - 1].subItems.push(text)
       } else {
-        // No parent bullet — treat as top-level
         topItems.push({ text, subItems: [] })
       }
     } else if (line.startsWith('- ')) {
@@ -84,16 +80,15 @@ function findTextPos(editor: Editor, searchText: string): { from: number, to: nu
   }
 
   const idx = fullText.toLowerCase().indexOf(searchLower)
-  if (idx >= 0) {
+  if (idx >= 0 && idx + searchText.length - 1 < posMap.length) {
     return { from: posMap[idx], to: posMap[idx + searchText.length - 1] + 1 }
   }
 
-  // Fallback: try matching first 30 chars (model often gets the tail wrong)
+  // Fallback: try matching first 30 chars
   if (searchLower.length > 30) {
     const partial = searchLower.slice(0, 30)
     const pidx = fullText.toLowerCase().indexOf(partial)
     if (pidx >= 0) {
-      // Find the end of the sentence/paragraph from that point
       const endIdx = Math.min(pidx + searchText.length, fullText.length)
       return { from: posMap[pidx], to: posMap[Math.min(endIdx - 1, posMap.length - 1)] + 1 }
     }
@@ -113,9 +108,27 @@ function getExistingHeadings(editor: Editor): Set<string> {
   return headings
 }
 
+// Clamp position to valid document range
+function clampPos(editor: Editor, pos: number): number {
+  return Math.max(0, Math.min(pos, editor.state.doc.content.size))
+}
+
 // Safe cursor helpers — catch mismatched transaction errors
 function safeCursor(editor: Editor, opts: { name: string, color: string, pos: number, selectionFrom?: number, selectionTo?: number, thought?: string }) {
-  try { editor.commands.setAgentCursor(opts) } catch { /* stale state, skip */ }
+  try {
+    const clamped = {
+      ...opts,
+      pos: clampPos(editor, opts.pos),
+      selectionFrom: opts.selectionFrom !== undefined ? clampPos(editor, opts.selectionFrom) : undefined,
+      selectionTo: opts.selectionTo !== undefined ? clampPos(editor, opts.selectionTo) : undefined,
+    }
+    // Ensure selection range is valid
+    if (clamped.selectionFrom !== undefined && clamped.selectionTo !== undefined && clamped.selectionFrom >= clamped.selectionTo) {
+      clamped.selectionFrom = undefined
+      clamped.selectionTo = undefined
+    }
+    editor.commands.setAgentCursor(clamped)
+  } catch { /* stale state, skip */ }
 }
 
 function safeRemoveCursor(editor: Editor, name: string) {
@@ -136,7 +149,7 @@ function typeTextAt(
   const typeNext = () => {
     if (charIdx < text.length) {
       const char = text[charIdx]
-      editor.commands.insertContentAt(pos + charIdx, char)
+      editor.commands.insertContentAt(clampPos(editor, pos + charIdx), char)
       charIdx++
       safeCursor(editor, {
         name: agentName,
@@ -146,9 +159,9 @@ function typeTextAt(
       timers[agentName] = window.setTimeout(typeNext, 25 + Math.random() * 45)
     } else {
       cb.onStateChange('idle')
-      setTimeout(() => {
+      timers[agentName] = window.setTimeout(() => {
         safeRemoveCursor(editor, agentName)
-        cb.onDone()
+        cb.onDone(true)
       }, 800)
     }
   }
@@ -165,15 +178,24 @@ export function executeAgentAction(
   callbacks: ActionCallbacks
 ) {
   const needsLock = action.type === 'insert' || action.type === 'replace'
+
+  // Atomic lock check: verify lock is still free at execution time
   if (needsLock && editorLockRef.current && editorLockRef.current !== agentName) {
-    setTimeout(() => executeAgentAction(editor, agentName, action, editorLockRef, timers, callbacks), 1000 + Math.random() * 1500)
+    timers[agentName] = window.setTimeout(() => {
+      // Re-check lock atomically before retrying
+      if (editorLockRef.current && editorLockRef.current !== agentName) {
+        timers[agentName] = window.setTimeout(() => executeAgentAction(editor, agentName, action, editorLockRef, timers, callbacks), 500 + Math.random() * 1000)
+      } else {
+        executeAgentAction(editor, agentName, action, editorLockRef, timers, callbacks)
+      }
+    }, 1000 + Math.random() * 1500)
     return
   }
   if (needsLock) editorLockRef.current = agentName
 
-  const releaseLockAndDone = () => {
+  const releaseLockAndDone = (success?: boolean) => {
     if (needsLock) editorLockRef.current = null
-    callbacks.onDone()
+    callbacks.onDone(success)
   }
 
   const postChatBefore = () => {
@@ -200,17 +222,16 @@ export function executeAgentAction(
       selectionTo: found?.to,
       thought: action.thought || 'Reading...',
     })
-    setTimeout(() => {
+    timers[agentName] = window.setTimeout(() => {
       callbacks.onStateChange('idle')
       safeRemoveCursor(editor, agentName)
       postChatAfter()
-      releaseLockAndDone()
+      releaseLockAndDone(true)
     }, 3500)
 
   } else if (action.type === 'insert') {
     postChatBefore()
     const existingHeadings = getExistingHeadings(editor)
-    // Filter out heading blocks that already exist in the document
     const chunks = contentToBlocks(action.content || '').filter(chunk => {
       const headingMatch = chunk.match(/^<h[123]>(.*?)<\/h[123]>$/)
       if (headingMatch) {
@@ -222,6 +243,12 @@ export function executeAgentAction(
       }
       return true
     })
+
+    if (chunks.length === 0) {
+      releaseLockAndDone(false)
+      return
+    }
+
     let insertPos = editor.state.doc.content.size
     if (action.position === 'after-heading') {
       editor.state.doc.descendants((node, pos) => {
@@ -235,23 +262,23 @@ export function executeAgentAction(
     safeCursor(editor, {
       name: agentName,
       color: AGENTS[agentName].color,
-      pos: insertPos,
+      pos: clampPos(editor, insertPos),
       thought: action.thought || 'Writing...',
     })
 
     let chunkIdx = 0
     const insertNext = () => {
       if (chunkIdx >= chunks.length) {
-        setTimeout(() => {
+        timers[agentName] = window.setTimeout(() => {
           safeRemoveCursor(editor, agentName)
           callbacks.onStateChange('idle')
           postChatAfter()
-          releaseLockAndDone()
+          releaseLockAndDone(true)
         }, 600)
         return
       }
       const chunk = chunks[chunkIdx]
-      const currentPos = editor.state.doc.content.size - 1
+      const currentPos = Math.max(0, editor.state.doc.content.size - 1)
       editor.commands.insertContentAt(currentPos, chunk)
       const newPos = editor.state.doc.content.size
       safeCursor(editor, {
@@ -270,7 +297,7 @@ export function executeAgentAction(
     const found = action.searchText ? findTextPos(editor, action.searchText) : null
     if (!found) {
       callbacks.onChatMessage(agentName, `[from doc] Couldn't find that text to replace. Can you be more specific?`)
-      releaseLockAndDone()
+      releaseLockAndDone(false)
       return
     }
 
@@ -284,7 +311,7 @@ export function executeAgentAction(
       thought: action.thought || 'Rewriting...',
     })
 
-    setTimeout(() => {
+    timers[agentName] = window.setTimeout(() => {
       editor.chain()
         .deleteRange({ from: found.from, to: found.to })
         .run()
@@ -295,12 +322,12 @@ export function executeAgentAction(
       })
       typeTextAt(editor, agentName, found.from, action.replaceWith || '', timers, {
         ...callbacks,
-        onDone: () => { postChatAfter(); releaseLockAndDone() },
+        onDone: (success) => { postChatAfter(); releaseLockAndDone(success) },
       })
     }, 1200)
 
   } else if (action.type === 'chat') {
     callbacks.onChatMessage(agentName, action.chatMessage || 'Got it.')
-    releaseLockAndDone()
+    releaseLockAndDone(true)
   }
 }

--- a/src/agent-cursor.ts
+++ b/src/agent-cursor.ts
@@ -89,12 +89,12 @@ export const AgentCursors = Extension.create({
 
               // Selection highlight
               if (cursor.selectionFrom !== undefined && cursor.selectionTo !== undefined) {
-                const from = Math.min(cursor.selectionFrom, state.doc.content.size)
-                const to = Math.min(cursor.selectionTo, state.doc.content.size)
+                const from = Math.max(0, Math.min(cursor.selectionFrom, state.doc.content.size))
+                const to = Math.max(0, Math.min(cursor.selectionTo, state.doc.content.size))
                 if (from < to) {
                   decorations.push(
                     Decoration.inline(from, to, {
-                      style: `background: ${cursor.color}18;`,
+                      style: `background: ${cursor.color}30;`,
                     }, { key: `sel-${cursor.name}` })
                   )
                 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -238,8 +238,15 @@ export async function askAgent(params: AskParams): Promise<AgentAction> {
           generationConfig: {
             responseMimeType: 'application/json',
             temperature: 0.7,
-            maxOutputTokens: 1200, // enough for JSON action responses with content
+            maxOutputTokens: 1200,
           },
+          safetySettings: [
+            { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+            { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' },
+          ],
         }),
       })
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -37,12 +37,31 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
   const typingTimers: Record<string, number> = {}
   const pendingInstructions: Record<string, { trigger: AskParams['trigger'], instruction: string }> = {}
   let lastActionDescription: Record<string, string> = {}
-  // Track how many autonomous turns each agent has taken (cap to avoid runaway API calls)
-  const autonomousTurnCount: Record<string, number> = { Aiden: 0, Nova: 0 }
-  const MAX_AUTONOMOUS_TURNS = 3 // max turns per agent per doc-opened session
-  // Track agent-to-agent tagging to prevent loops
-  let agentTagCount = 0
-  const MAX_AGENT_TAGS = 2 // max back-and-forth exchanges before cooling off
+  // Track total turns per agent (caps all non-user-initiated work)
+  const turnCount: Record<string, number> = { Aiden: 0, Nova: 0 }
+  const MAX_TURNS = 4
+  // Track back-and-forth exchanges
+  let exchangeCount = 0
+  const MAX_EXCHANGES = 4
+  // Track pending doc-edit reaction to prevent double-triggers
+  let pendingReaction: AgentName | null = null
+  // Track ALL scheduled timeouts so we can clear them on destroy/user-message
+  const scheduledTimers = new Set<number>()
+
+  function scheduleTimeout(fn: () => void, ms: number): number {
+    const id = window.setTimeout(() => {
+      scheduledTimers.delete(id)
+      fn()
+    }, ms)
+    scheduledTimers.add(id)
+    return id
+  }
+
+  function clearAllTimers() {
+    scheduledTimers.forEach(id => clearTimeout(id))
+    scheduledTimers.clear()
+    Object.values(typingTimers).forEach(t => clearTimeout(t))
+  }
 
   function enqueue(req: TurnRequest) {
     if (destroyed) return
@@ -83,13 +102,13 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
       const callbacks: ActionCallbacks = {
         onStateChange: (status, thought) => config.onAgentState(req.agent, status, thought),
         onChatMessage: (from, text) => config.onChatMessage(from, text),
-        onDone: () => {
-          log('done', req.agent, action.type, 'shouldContinue:', action.shouldContinue)
+        onDone: (success?: boolean) => {
+          if (destroyed) return
+          log('done', req.agent, action.type, 'success:', success, 'shouldContinue:', action.shouldContinue)
           const actionDesc = describeAction(req.agent, action)
           lastActionDescription[req.agent] = actionDesc
-          if (req.trigger === 'autonomous') {
-            autonomousTurnCount[req.agent]++
-          }
+          turnCount[req.agent]++
+          if (pendingReaction === req.agent) pendingReaction = null
           processing = false
 
           // Process queued instruction — but skip if it's the same one we just ran
@@ -102,11 +121,14 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
             }
           }
 
-          // After a doc edit, prompt the OTHER agent to react — creates back-and-forth
-          if ((action.type === 'insert' || action.type === 'replace') && queue.length === 0) {
+          // After a SUCCESSFUL doc edit, prompt the OTHER agent to react
+          const didEdit = (action.type === 'insert' || action.type === 'replace') && success !== false
+          if (didEdit && queue.length === 0) {
             const other: AgentName = req.agent === 'Aiden' ? 'Nova' : 'Aiden'
-            if (autonomousTurnCount[other] < MAX_AUTONOMOUS_TURNS) {
-              setTimeout(() => {
+            if (exchangeCount < MAX_EXCHANGES && turnCount[other] < MAX_TURNS && pendingReaction !== other) {
+              exchangeCount++
+              pendingReaction = other
+              scheduleTimeout(() => {
                 if (!destroyed) {
                   enqueue({
                     agent: other,
@@ -116,7 +138,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
                 }
               }, 3000 + Math.random() * 2000)
             }
-          } else if (action.shouldContinue && autonomousTurnCount[req.agent] < MAX_AUTONOMOUS_TURNS) {
+          } else if (action.shouldContinue && turnCount[req.agent] < MAX_TURNS) {
             enqueue({ agent: req.agent, trigger: 'autonomous' })
           } else {
             processQueue()
@@ -148,21 +170,20 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
     switch (type) {
       case 'doc-opened':
-        // Reset turn counters for new session
-        autonomousTurnCount.Aiden = 0
-        autonomousTurnCount.Nova = 0
-        // Each agent gets a directed first task matching their expertise
-        setTimeout(() => enqueue({
+        turnCount.Aiden = 0
+        turnCount.Nova = 0
+        exchangeCount = 0
+        pendingReaction = null
+        scheduleTimeout(() => enqueue({
           agent: 'Aiden',
           trigger: 'instruction',
           instruction: 'Review the doc and add technical depth — architecture details, system design, implementation specifics. Use your engineering expertise.',
         }), 2500)
-        setTimeout(() => enqueue({
+        scheduleTimeout(() => enqueue({
           agent: 'Nova',
           trigger: 'instruction',
           instruction: 'Review the doc and address the open questions from a product/user perspective — user scenarios, adoption risks, edge cases. Use your product strategy expertise.',
         }), 6000)
-        // Follow-up turns happen naturally via the back-and-forth mechanism in onDone
         break
 
       case 'user-message': {
@@ -172,13 +193,15 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         const mentionsNova = lower.includes('nova') || lower.includes('@nova')
         const mentionsBoth = !mentionsAiden && !mentionsNova
 
-        // User messages take priority — clear ALL queued turns and pending instructions
+        // User messages take priority — clear everything
         queue.length = 0
         delete pendingInstructions['Aiden']
         delete pendingInstructions['Nova']
-
-        // Reset agent tag counter — user is re-engaging
-        agentTagCount = 0
+        // Cancel all pending reaction timeouts
+        scheduledTimers.forEach(id => clearTimeout(id))
+        scheduledTimers.clear()
+        exchangeCount = 0
+        pendingReaction = null
 
         if (mentionsAiden || mentionsBoth) {
           if (processing) {
@@ -198,33 +221,34 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
       }
 
       case 'agent-tagged': {
-        // Limit agent-to-agent exchanges to prevent infinite loops
-        agentTagCount++
-        if (agentTagCount > MAX_AGENT_TAGS) {
-          log('agent-to-agent tag limit reached, ignoring')
-          break
-        }
         const target = payload?.agent
         const from = payload?.from || 'someone'
-        if (target) {
+        if (target && pendingReaction === target) {
+          log('agent-tagged skipped — already has pending reaction', target)
+          break
+        }
+        if (exchangeCount >= MAX_EXCHANGES) {
+          log('exchange limit reached, ignoring agent tag')
+          break
+        }
+        if (target && turnCount[target] < MAX_TURNS) {
+          exchangeCount++
           enqueue({ agent: target, trigger: 'instruction', instruction: `${from} just mentioned you in chat. Read the recent chat and respond to their latest message.` })
         }
         break
       }
 
       case 'turn-complete':
-        // Handled internally
         break
     }
   }
 
   function onMessage(from: string, text: string) {
-    // Only trigger on explicit @mentions (not just name in text) to avoid loops
     if (from === 'Aiden' || from === 'Nova') {
       const other: AgentName = from === 'Aiden' ? 'Nova' : 'Aiden'
       if (text.toLowerCase().includes('@' + other.toLowerCase())) {
-        setTimeout(() => {
-          trigger('agent-tagged', { agent: other, from, instruction: text })
+        scheduleTimeout(() => {
+          trigger('agent-tagged', { agent: other, from })
         }, 2000 + Math.random() * 2000)
       }
     }
@@ -232,13 +256,14 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
   function destroy() {
     destroyed = true
-    Object.values(typingTimers).forEach(t => clearTimeout(t))
+    clearAllTimers()
     queue.length = 0
     processing = false
     editorLockRef.current = null
-    autonomousTurnCount.Aiden = 0
-    autonomousTurnCount.Nova = 0
-    agentTagCount = 0
+    turnCount.Aiden = 0
+    turnCount.Nova = 0
+    exchangeCount = 0
+    pendingReaction = null
   }
 
   return { trigger, onMessage, destroy }


### PR DESCRIPTION
## Summary
- Fix timer leaks: all scheduled timeouts tracked in a `Set` and cleared on destroy/user-message, preventing stale reactions from firing after orchestrator reset
- Fix editor lock race condition: retry callback now re-checks lock atomically before acquiring
- Fix exchangeCount incrementing on failed actions (replace text-not-found, empty inserts) by passing `success` flag through `onDone`
- Clamp cursor positions to document bounds and validate selection ranges to prevent ProseMirror errors
- Show "thinking" status in doc status chips (previously only reading/writing were visible)
- Add mobile responsive breakpoint (640px) to stack chat/doc vertically
- Increase agent selection highlight opacity from 2.3% to 19%
- Remove Gemini API content filters (safetySettings `BLOCK_NONE` for all categories)

## Test plan
- [ ] Open doc, verify agents take turns editing without infinite loops
- [ ] Send user message mid-agent-work, verify agents respond to user not stale reactions
- [ ] Close and reopen doc rapidly, verify no ghost agent actions from old session
- [ ] Verify "thinking" chip appears in status bar when agent is processing
- [ ] Test on narrow viewport (<640px) for mobile layout
- [ ] Verify replace failures don't trigger back-and-forth reactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/collab/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
