### PR TITLE
Remove VITE_GEMINI_API_KEY to prevent client bundle exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ npm install
 Create a `.env.local` file in the project root:
 
 ```env
-# Used by the client in development (never commit this file)
-VITE_GEMINI_API_KEY=your_gemini_api_key_here
+# Used by the server-side proxy (never exposed to the client)
+GEMINI_API_KEY=your_gemini_api_key_here
 ```
 
-> **Note:** The `VITE_` prefix exposes the key in the browser bundle — this is acceptable for local development only. For production, use the serverless proxy (see [Deployment](#deployment)).
+> **Note:** The API key is only read server-side by the `/api/gemini` proxy. It is never bundled into the client.
 
 ### 3. Start the dev server
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,9 +1,5 @@
-const DEV_API_KEY = import.meta.env.VITE_GEMINI_API_KEY as string | undefined
-const MODEL = 'gemini-2.5-flash'
-// In production, use serverless proxy (no API key on client). In dev, call Gemini directly.
-const DIRECT_URL = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${DEV_API_KEY || ''}`
-const PROXY_URL = '/api/gemini'
-const API_URL = DEV_API_KEY ? DIRECT_URL : PROXY_URL
+// All API calls go through the server-side proxy to avoid exposing API keys in the client bundle.
+const API_URL = '/api/gemini'
 
 // Rate limiter: tracks calls, enforces spacing, handles 429 backoff
 const rateLimiter = {
@@ -302,6 +298,12 @@ export async function askAgent(params: AskParams): Promise<AgentAction> {
       return action
     } catch (err) {
       console.error('[agent] catch error:', err)
+      if (err instanceof TypeError && (err as TypeError).message === 'Failed to fetch') {
+        console.error(
+          '[agent] Could not reach the API proxy at /api/gemini. ' +
+          'Make sure the server-side proxy is running and GEMINI_API_KEY is set in your environment.'
+        )
+      }
       rateLimiter.onError()
       if (attempt < rateLimiter.maxRetries) {
         await rateLimiter.waitForSlot()


### PR DESCRIPTION
## Summary

- Removed `VITE_GEMINI_API_KEY` fallback from `src/agent.ts` that caused the API key to be embedded in the Vite client bundle
- All Gemini API calls now go exclusively through the `/api/gemini` server-side proxy
- Added a clear error message when the proxy endpoint is unreachable, guiding developers to check their server setup and `GEMINI_API_KEY` env var
- Updated README to reference `GEMINI_API_KEY` (server-only) instead of `VITE_GEMINI_API_KEY`

## Test plan

- [ ] Run `npm run build` and verify no `VITE_GEMINI_API_KEY` references in `dist/` output
- [ ] Start dev server with proxy running and confirm agent calls succeed through `/api/gemini`
- [ ] Start dev server without proxy and confirm the error message appears in console

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/collab/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
