### PR TITLE
Fix blank page for logged-out users by gating app shell

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,8 +256,12 @@ function AgentActivityBar({ agents, getAgentState }: { agents: AgentConfig[], ge
 
 const EMPTY_DOC = '<h1>Untitled</h1><p></p>'
 
-function App() {
-  const { user, loading: authLoading, signOut } = useAuth()
+interface AppShellProps {
+  onSignOut?: () => Promise<void>
+  forceHome?: boolean
+}
+
+function AppShell({ onSignOut, forceHome = false }: AppShellProps) {
   const [demoMode, setDemoMode] = useState(false)
   const [activeSession, setActiveSession] = useState<Session | null>(null)
   const activeSessionRef = useRef<Session | null>(null)
@@ -568,23 +572,12 @@ function App() {
     }, 300)
   }
 
-  const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
-  const params = new URLSearchParams(window.location.search)
-
-  // Test routes for UI development
-  if (params.has('home')) {
-    return <HomePage onSelect={handleSessionSelect} onSignOut={signOut} demoMode={demoMode} onDemoConsumed={() => setDemoMode(false)} />
-  }
-  if (params.has('login')) {
-    return <LoginPage />
-  }
-
-  if (!isLocalhost && (authLoading || !user)) {
-    return <LoginPage />
+  if (forceHome) {
+    return <HomePage onSelect={handleSessionSelect} onSignOut={onSignOut} demoMode={demoMode} onDemoConsumed={() => setDemoMode(false)} />
   }
 
   if (!activeSession) {
-    return <HomePage onSelect={handleSessionSelect} onSignOut={isLocalhost ? undefined : signOut} demoMode={demoMode} onDemoConsumed={() => setDemoMode(false)} />
+    return <HomePage onSelect={handleSessionSelect} onSignOut={onSignOut} demoMode={demoMode} onDemoConsumed={() => setDemoMode(false)} />
   }
 
   return (
@@ -767,6 +760,23 @@ function App() {
       </div>
     </div>
   )
+}
+
+function App() {
+  const { user, loading: authLoading, signOut } = useAuth()
+  const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+  const params = new URLSearchParams(window.location.search)
+
+  // Test routes for UI development
+  if (params.has('login')) {
+    return <LoginPage />
+  }
+
+  if (!params.has('home') && !isLocalhost && (authLoading || !user)) {
+    return <LoginPage />
+  }
+
+  return <AppShell onSignOut={isLocalhost ? undefined : signOut} forceHome={params.has('home')} />
 }
 
 export default App

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -82,10 +82,11 @@ describe('createOrchestrator', () => {
     const config = makeConfig()
     const orch = createOrchestrator(config)
     orch.trigger('doc-opened')
-    // Should have scheduled 2 timers (Aiden at 2500ms, Nova at 6000ms)
-    expect(timers.length).toBe(2)
-    expect(timers[0].ms).toBe(2500)
-    expect(timers[1].ms).toBe(6000)
+    // Should have scheduled 3 timers: heartbeat first, then Aiden at 2500ms, Nova at 6000ms
+    expect(timers.length).toBe(3)
+    expect(timers[0].ms).toBeGreaterThanOrEqual(20000) // heartbeat
+    expect(timers[1].ms).toBe(2500) // Aiden
+    expect(timers[2].ms).toBe(6000) // Nova
     orch.destroy()
   })
 


### PR DESCRIPTION
- [x] Investigate CI test failure: `trigger doc-opened schedules both agents` expects 2 timers but receives 3
- [x] Fix failing test — updated assertion to account for heartbeat timer (scheduled first) + 2 agent timers, with correct order and value checks
- [x] `npm run build` passes
- [x] All 46 tests pass