### PR TITLE
fix: update orchestrator test for heartbeat timer

### DIFF
--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -82,10 +82,12 @@ describe('createOrchestrator', () => {
     const config = makeConfig()
     const orch = createOrchestrator(config)
     orch.trigger('doc-opened')
-    // Should have scheduled 2 timers (Aiden at 2500ms, Nova at 6000ms)
-    expect(timers.length).toBe(2)
-    expect(timers[0].ms).toBe(2500)
-    expect(timers[1].ms).toBe(6000)
+    // Should have scheduled 3 timers: heartbeat + Aiden at 2500ms + Nova at 6000ms
+    expect(timers.length).toBe(3)
+    // First timer is the heartbeat (random delay 20000-30000ms)
+    expect(timers[0].ms).toBeGreaterThanOrEqual(20000)
+    expect(timers[1].ms).toBe(2500)
+    expect(timers[2].ms).toBe(6000)
     orch.destroy()
   })
 

--- a/src/__tests__/orchestrator.test.ts
+++ b/src/__tests__/orchestrator.test.ts
@@ -86,6 +86,7 @@ describe('createOrchestrator', () => {
     expect(timers.length).toBe(3)
     // First timer is the heartbeat (random delay 20000-30000ms)
     expect(timers[0].ms).toBeGreaterThanOrEqual(20000)
+    expect(timers[0].ms).toBeLessThanOrEqual(30000)
     expect(timers[1].ms).toBe(2500)
     expect(timers[2].ms).toBe(6000)
     orch.destroy()


### PR DESCRIPTION
- [x] Updated test assertion from `toBe(2)` to `toBe(3)` to account for heartbeat timer created by `startHeartbeat()` on `doc-opened`
- [x] Added check that first timer is the heartbeat (range 20000-30000ms) — both lower and upper bounds
- [x] All 46 tests pass, build clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
