### PR TITLE
feat: wire task components into chat and editor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,7 +221,6 @@ function App() {
       if (saved.length > 0) setTasks(prev => [...prev, ...saved])
     }).catch(console.error)
   }, [activeSessionRef])
-  void handleAddTask // will be used by TaskCard in chat rendering
 
   // Orchestrator hook -- populates orchestratorRef
   useOrchestrator({
@@ -433,6 +432,7 @@ function App() {
                   setMessages={setMessages}
                   now={now}
                   uid={uid}
+                  tasks={tasks}
                 />
               </ErrorBoundary>
             )}
@@ -476,6 +476,7 @@ function App() {
                   onRejectProposal={(id) => {
                     setMessages(prev => prev.map(msg => msg.id === id && msg.proposal ? { ...msg, proposal: { ...msg.proposal, status: 'rejected' as const } } : msg))
                   }}
+                  onAddTask={handleAddTask}
                   chatWidth={chatWidth}
                 />
               </TamboProvider>

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -4,11 +4,14 @@ import { BlobAvatar } from '../blob-avatar'
 import { ShapeAvatar } from './ShapeAvatar'
 import { AgentHoverCard } from './AgentHoverCard'
 import { ReasoningChain } from './ReasoningChain'
-import type { Message, AgentState } from '../types'
+import { TaskCard } from './TaskCard'
+import type { Message, AgentState, AgentTask } from '../types'
 
-export const ChatMessage = memo(({ m, sameSender, agentState, userAvatarUrl, onApproveProposal, onRejectProposal }: {
+export const ChatMessage = memo(({ m, sameSender, agentState, userAvatarUrl, onApproveProposal, onRejectProposal, onAddTask, onDismissTask }: {
   m: Message, sameSender: boolean, agentState?: AgentState | null, userAvatarUrl?: string,
-  onApproveProposal?: (id: string) => void, onRejectProposal?: (id: string) => void
+  onApproveProposal?: (id: string) => void, onRejectProposal?: (id: string) => void,
+  onAddTask?: (task: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor'>) => void,
+  onDismissTask?: () => void,
 }) => {
   const isAgent = m.from !== 'You' && m.from !== 'Sarah' && m.from !== 'System'
   const displayText = m.text.replace('[from doc] ', '')
@@ -103,6 +106,9 @@ export const ChatMessage = memo(({ m, sameSender, agentState, userAvatarUrl, onA
         )}
         {m.proposal && m.proposal.status === 'rejected' && (
           <span className="msg-proposal-status msg-proposal-dismissed">Dismissed</span>
+        )}
+        {m.taskEvent && (
+          <TaskCard event={m.taskEvent} onAdd={onAddTask} onDismiss={onDismissTask} />
         )}
       </div>
     </div>

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -1,8 +1,9 @@
 import { EditorContent } from '@tiptap/react'
 import type { Editor } from '@tiptap/react'
 import { Timeline } from './Timeline'
+import { TaskProgress } from './TaskProgress'
 import { supabase } from '../lib/supabase'
-import type { TimelineEntry, Session, Message } from '../types'
+import type { TimelineEntry, Session, Message, AgentTask } from '../types'
 
 interface EditorPanelProps {
   editor: Editor
@@ -16,6 +17,7 @@ interface EditorPanelProps {
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
   now: () => string
   uid: () => string
+  tasks?: AgentTask[]
 }
 
 export function EditorPanel({
@@ -30,6 +32,7 @@ export function EditorPanel({
   setMessages,
   now,
   uid,
+  tasks,
 }: EditorPanelProps) {
   return (
     <div className="doc-panel" role="main" aria-label="Document editor">
@@ -136,6 +139,12 @@ export function EditorPanel({
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.13-9.36L23 10"/></svg>
         </button>
+        {tasks && tasks.length > 0 && (
+          <>
+            <span className="doc-toolbar-sep" role="separator" />
+            <TaskProgress tasks={tasks} />
+          </>
+        )}
         <span className="doc-toolbar-spacer" />
         <button
           className="doc-toolbar-btn"

--- a/src/components/TamboChat.tsx
+++ b/src/components/TamboChat.tsx
@@ -5,7 +5,7 @@ import { BlobAvatar } from '../blob-avatar'
 import { ChatMessage } from './ChatMessage'
 import { ShapeAvatar } from './ShapeAvatar'
 import DOMPurify from 'dompurify'
-import type { Message, AgentState, AgentConfig } from '../types'
+import type { Message, AgentState, AgentConfig, AgentTask } from '../types'
 
 const SLASH_COMMANDS = ['/outline', '/analytics', '/suggestions', '/insights', '/research', '/ask', '/expand', '/summarize', '/tone', '/checklist', '/compare'] as const
 
@@ -20,6 +20,7 @@ interface ChatPanelProps {
   onSendSuggestion: (text: string) => void
   onApproveProposal: (id: string) => void
   onRejectProposal: (id: string) => void
+  onAddTask?: (task: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor'>) => void
   chatWidth: number
 }
 
@@ -72,6 +73,7 @@ export function TamboChat({
   onSendSuggestion,
   onApproveProposal,
   onRejectProposal,
+  onAddTask,
   chatWidth,
 }: ChatPanelProps) {
   const chatEndRef = useRef<HTMLDivElement>(null)
@@ -242,6 +244,7 @@ export function TamboChat({
                   userAvatarUrl={userAvatarUrl}
                   onApproveProposal={onApproveProposal}
                   onRejectProposal={onRejectProposal}
+                  onAddTask={onAddTask}
                 />
               )
             }


### PR DESCRIPTION
## Summary
- TaskCard renders inline in chat when messages have `taskEvent`
- TaskProgress dots display in editor toolbar (right side)
- `onAddTask` prop flows through App → TamboChat → ChatMessage → TaskCard
- Tasks passed to EditorPanel for progress indicator

Builds on #135. Completes the UI wiring so task cards are visible in the chat stream and progress is tracked in the toolbar.

## Test plan
- [ ] Start a session, agent task proposals render as cards in chat
- [ ] Task completion banners appear with green check
- [ ] Progress dots visible in editor toolbar when tasks exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
