### PR TITLE
feat: wire task loading and work plan flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,8 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { buildCommands } from './lib/commands'
 import { useToast } from './components/Toast'
 import { ProgressBar } from './components/ProgressBar'
+import { WorkPlanCard } from './components/WorkPlanCard'
+import { resolvePresetTasks } from './task-presets'
 
 // Custom hooks
 import { useOrchestrator } from './hooks/useOrchestrator'
@@ -156,6 +158,9 @@ function App() {
   const [tasks, setTasks] = useState<AgentTask[]>([])
   const tasksRef = useRef(tasks)
   tasksRef.current = tasks
+  const [workPlan, setWorkPlan] = useState<{ presetId: string; presetTitle: string; tasks: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor' | 'order'>[] } | null>(null)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pendingStarterRef = useRef<any>(null)
 
   // Stable orchestrator ref -- shared between useSession and useOrchestrator
   const orchestratorRef = useRef<ReturnType<typeof import('./orchestrator').createOrchestrator> | null>(null)
@@ -177,6 +182,7 @@ function App() {
     lastProcessedMsg,
     orchestratorRef,
     messagesRef,
+    setTasks,
   })
 
   // Task callbacks (must be after useSession for activeSessionRef)
@@ -490,12 +496,55 @@ function App() {
             sessionsLoaded={sessionsLoaded}
             onNewDoc={() => setShowTemplatePicker(true)}
             onSelectSession={(s) => handleSessionSelect(s, [])}
-            onStarterPick={(starter) => handleTemplatePick(starter)}
+            onStarterPick={(starter) => {
+              const resolvedTasks = resolvePresetTasks(starter.id, starter.agents.map(a => a.name))
+              if (resolvedTasks.length > 0) {
+                // Store starter for later and show work plan
+                pendingStarterRef.current = starter
+                setWorkPlan({ presetId: starter.id, presetTitle: starter.title, tasks: resolvedTasks })
+              } else {
+                handleTemplatePick(starter)
+              }
+            }}
           />
         )}
       </div>
       </div>
       </div>
+      {workPlan && (
+        <WorkPlanCard
+          presetTitle={workPlan.presetTitle}
+          tasks={workPlan.tasks}
+          onStart={async (finalTasks) => {
+            const starter = pendingStarterRef.current
+            if (!starter) return
+            pendingStarterRef.current = null
+            setWorkPlan(null)
+            // Create the session via normal flow
+            await handleTemplatePick(starter)
+            // Save tasks to the newly created session
+            const session = activeSessionRef.current
+            if (session && finalTasks.length > 0) {
+              const taskRows = finalTasks.map((t, i) => ({
+                sessionId: session.id,
+                title: t.title,
+                status: 'pending' as const,
+                assignedAgents: t.assignedAgents,
+                createdBy: 'user',
+                sectionAnchor: t.sectionAnchor,
+                order: i + 1,
+              }))
+              saveAgentTasks(session.id, taskRows).then(saved => {
+                setTasks(saved)
+              }).catch(console.error)
+            }
+          }}
+          onCancel={() => {
+            pendingStarterRef.current = null
+            setWorkPlan(null)
+          }}
+        />
+      )}
       {showExperiments && (
         <Suspense>
           <ExperimentControls

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -79,7 +79,7 @@ interface Props {
   sessionsLoaded: boolean
   onNewDoc: () => void
   onSelectSession: (session: Session) => void
-  onStarterPick?: (starter: { title: string, template: DocTemplate, agents: AgentConfig[] }) => void
+  onStarterPick?: (starter: { id: string, title: string, template: DocTemplate, agents: AgentConfig[] }) => void
 }
 
 function getGreeting() {
@@ -115,7 +115,7 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
               <button
                 key={s.id}
                 className="home-starter-card"
-                onClick={() => onStarterPick({ title: s.title, template: s.template, agents: s.agents })}
+                onClick={() => onStarterPick({ id: s.id, title: s.title, template: s.template, agents: s.agents })}
               >
                 <div className="home-starter-dots">
                   {s.agents.slice(0, 4).map(a => (

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,11 +1,11 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { listSessions, getSession, createSession, loadDocument, loadChatMessages, loadAgentPersonas, saveAgentPersonas, saveDocument } from '../lib/session-store'
+import { listSessions, getSession, createSession, loadDocument, loadChatMessages, loadAgentPersonas, saveAgentPersonas, saveDocument, loadAgentTasks } from '../lib/session-store'
 import { DOC_TEMPLATES } from '../templates'
 import { supabase } from '../lib/supabase'
 import { DEFAULT_PERSONAS } from '../agent'
 import { agentConfigsToPersonas } from '../components/SessionHeader'
 import { events } from '../lib/analytics'
-import type { Session, AgentConfig, Message, AgentState } from '../types'
+import type { Session, AgentConfig, Message, AgentState, AgentTask } from '../types'
 import type { Editor } from '@tiptap/react'
 import type { GoogleDocFile } from '../TemplatePickerModal'
 
@@ -35,6 +35,7 @@ interface UseSessionOptions {
   lastProcessedMsg: React.MutableRefObject<number>
   orchestratorRef: React.RefObject<ReturnType<typeof import('../orchestrator').createOrchestrator> | null>
   messagesRef: React.RefObject<Message[]>
+  setTasks?: React.Dispatch<React.SetStateAction<AgentTask[]>>
 }
 
 export function useSession({
@@ -47,6 +48,7 @@ export function useSession({
   lastProcessedMsg,
   orchestratorRef,
   messagesRef,
+  setTasks,
 }: UseSessionOptions) {
   const [activeSession, setActiveSession] = useState<Session | null>(null)
   const activeSessionRef = useRef<Session | null>(null)
@@ -77,6 +79,7 @@ export function useSession({
     setAgentStates({})
     setSaveStatus('idle')
     lastProcessedMsg.current = 0
+    setTasks?.([])  // Reset tasks on session switch
 
     setActiveSession(session)
     activeSessionRef.current = session
@@ -91,11 +94,17 @@ export function useSession({
     }
 
     // Load existing doc + messages + agent personas from Supabase
-    const [savedDoc, savedMessages, savedPersonas] = await Promise.all([
+    const [savedDoc, savedMessages, savedPersonas, savedTasks] = await Promise.all([
       loadDocument(session.id).catch(() => null),
       loadChatMessages(session.id).catch(() => []),
       loadAgentPersonas(session.id).catch(() => []),
+      loadAgentTasks(session.id).catch(() => []),
     ])
+
+    // Restore tasks
+    if (savedTasks.length > 0) {
+      setTasks?.(savedTasks)
+    }
 
     // Restore agent personas if saved, otherwise use provided or current agents
     let currentAgents: AgentConfig[]


### PR DESCRIPTION
## Summary
- Load saved tasks from DB when reopening a session
- WorkPlanCard modal shows after picking a preset (before session starts)
- User can review, remove tasks, then hit Start Writing
- Tasks saved to DB and loaded into state on session start
- HomeDashboard passes starter id for preset task resolution

## Test plan
- [ ] Pick "Product Brief" preset — Work Plan card should appear
- [ ] Remove a task from the plan, click Start Writing
- [ ] Verify tasks load when reopening a session
- [ ] Blank Canvas preset skips the plan (no preset tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
