### PR TITLE
chore: gitignore output and tmp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 *.sw?
 .vercel
 .worktrees
+
+# Generated artifacts
+output
+tmp


### PR DESCRIPTION
These directories hold generated artifacts (PDF output, temp files) and shouldn't be tracked. They currently show up as untracked in git status.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/152" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
