### PR TITLE
chore: remove unused TokenRecord and ALLOWED_TAGS

### DIFF
--- a/api/google/_utils.ts
+++ b/api/google/_utils.ts
@@ -5,11 +5,6 @@ const supabase = createClient(
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY || '',
 )
 
-interface TokenRecord {
-  google_refresh_token: string
-  google_scopes: string
-}
-
 export async function getGoogleAccessToken(userId: string): Promise<string> {
   const { data, error } = await supabase
     .from('user_tokens')

--- a/api/google/docs/import.ts
+++ b/api/google/docs/import.ts
@@ -1,9 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { getGoogleAccessToken, googleFetch, GoogleAuthError } from '../_utils'
 
-// Simple HTML sanitizer — allows only safe tags
-const ALLOWED_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong', 'em', 'a', 'ul', 'ol', 'li', 'br', 'table', 'tr', 'td', 'th', 'tbody', 'thead'])
-
+// Simple HTML sanitizer — allows only safe tags (p, h1-h6, strong, em, a, ul, ol, li, br, table, tr, td, th, tbody, thead)
 function sanitizeHtml(html: string): string {
   // Strip <style> blocks
   let clean = html.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')


### PR DESCRIPTION
TokenRecord interface is never referenced. ALLOWED_TAGS was declared but sanitizeHtml uses hardcoded regex tags; moved the list into a comment for clarity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
