### PR TITLE
fix: add noopener to source link in ChatMessage

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -80,7 +80,7 @@ export const ChatMessage = memo(({ m, sameSender, agentState, userAvatarUrl, onA
                 <ul>
                   {m.proposal.edit.sources.map((s, i) => (
                     <li key={i}>
-                      <a href={s.url} target="_blank" rel="noreferrer">{s.title || s.url}</a>
+                      <a href={s.url} target="_blank" rel="noopener noreferrer">{s.title || s.url}</a>
                       {s.quote ? <span className="msg-edit-quote"> {s.quote.slice(0, 120)}{s.quote.length > 120 ? '…' : ''}</span> : null}
                     </li>
                   ))}


### PR DESCRIPTION
Source links open in new tab but only had rel=noreferrer. Adding noopener for explicit protection against tabnabbing (matches pattern used everywhere else in the codebase).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
