### PR TITLE
fix: rename ref props in useSession to Ref suffix

### DIFF
--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -44,8 +44,8 @@ export function useSession({
   setTimeline,
   setAgentStates,
   setSaveStatus,
-  lastDocSnapshot,
-  lastProcessedMsg,
+  lastDocSnapshot: lastDocSnapshotRef,
+  lastProcessedMsg: lastProcessedMsgRef,
   orchestratorRef,
   messagesRef,
   setTasks,
@@ -78,7 +78,7 @@ export function useSession({
     setTimeline([])
     setAgentStates({})
     setSaveStatus('idle')
-    lastProcessedMsg.current = 0
+    lastProcessedMsgRef.current = 0
     setTasks?.([])  // Reset tasks on session switch
 
     setActiveSession(session)
@@ -141,9 +141,9 @@ export function useSession({
         id: m.id, from: m.sender, text: m.text, time: new Date(m.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }), reasoning: m.reasoning || undefined,
       }))
       setMessages(restored)
-      lastProcessedMsg.current = restored.length
+      lastProcessedMsgRef.current = restored.length
     }
-    lastDocSnapshot.current = editor?.getText() || ''
+    lastDocSnapshotRef.current = editor?.getText() || ''
 
     // Reset doc scroll to top
     requestAnimationFrame(() => {


### PR DESCRIPTION
Destructured ref props needed Ref suffix so react-hooks/immutability recognizes them as refs and stops flagging mutations as prop modification. Internal-only rename; call-site unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
