### PR TITLE
fix: sync stateRef in effect instead of during render

### DIFF
--- a/src/blob-avatar.tsx
+++ b/src/blob-avatar.tsx
@@ -47,7 +47,7 @@ export const BlobAvatar = memo(({ name, size = 28, state = 'idle', color }: Blob
   const rafRef = useRef<number>(0)
   const stateRef = useRef(state)
   const fillRef = useRef(STATE_CONFIG[state].fill)
-  stateRef.current = state
+  useEffect(() => { stateRef.current = state })
 
   const seed = SEEDS[name] ?? (name.charCodeAt(0) % 10)
   const agentColor = color || AGENT_COLORS[name] || '#1a1a1a'


### PR DESCRIPTION
Avoid the react-hooks/refs lint by syncing the latest state into the ref inside a commit-phase effect. Ref is consumed by the raf loop; behavior unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/157" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
