### PR TITLE
fix: sync onTaskActionRef inside effect in useOrchestrator

### DIFF
--- a/src/hooks/useOrchestrator.ts
+++ b/src/hooks/useOrchestrator.ts
@@ -42,7 +42,7 @@ export function useOrchestrator({
   const pendingReasoning = useRef<Record<string, string[]>>({})
   const prevAgentsRef = useRef<AgentConfig[]>(activeAgents)
   const onTaskActionRef = useRef(onTaskAction)
-  onTaskActionRef.current = onTaskAction
+  useEffect(() => { onTaskActionRef.current = onTaskAction })
   const hasInitialized = useRef(false)
 
   const makeOrchestrator = useCallback(() => {


### PR DESCRIPTION
Move ref mutation into a commit-phase effect to satisfy react-hooks/refs. Ref is consumed by event handlers within the orchestrator, so effect-time update is sufficient.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
