### PR TITLE
fix: sync togglePauseRef inside effect

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -11,7 +11,7 @@ interface ShortcutActions {
 export function useKeyboardShortcuts(actions: ShortcutActions) {
   // Use ref for togglePause to avoid stale closure issues
   const togglePauseRef = useRef(actions.togglePause)
-  togglePauseRef.current = actions.togglePause
+  useEffect(() => { togglePauseRef.current = actions.togglePause })
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {


### PR DESCRIPTION
Move ref mutation into a commit-phase effect to satisfy react-hooks/refs. Ref is consumed by a window keydown listener, so effect-time update is sufficient.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
