### PR TITLE
chore: remove stale eslint-disable comment

### DIFF
--- a/src/components/tambo/message-input.tsx
+++ b/src/components/tambo/message-input.tsx
@@ -43,7 +43,6 @@ import {
 } from "@tambo-ai/react-ui-base/message-input";
 
 // Lazy load DictationButton for code splitting (framework-agnostic alternative to next/dynamic)
-// eslint-disable-next-line @typescript-eslint/promise-function-async
 const LazyDictationButton = React.lazy(() => import("./dictation-button"));
 
 /**


### PR DESCRIPTION
The rule @typescript-eslint/promise-function-async is not enabled in the current config, making the disable comment a warning.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
