### PR TITLE
feat: add canonical link tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <meta name="description" content="AI agents that read your PRDs, specs, and briefs, then push back on gaps, risks, and weak assumptions. Four perspectives before you ship." />
     <meta name="author" content="n3wth" />
     <meta name="theme-color" content="#0e0e0e" />
+    <link rel="canonical" href="https://markup.so/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />


### PR DESCRIPTION
Canonical URL helps search engines consolidate signals to the apex domain when the site is reached via www.markup.so or other variants.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
