### PR TITLE
fix: replace any with JSONContent in textToContent

### DIFF
--- a/src/agent-actions.ts
+++ b/src/agent-actions.ts
@@ -1,4 +1,5 @@
 import type { Editor } from '@tiptap/react'
+import type { JSONContent } from '@tiptap/core'
 import type { AgentAction } from './agent'
 import { generateImage } from './lib/image-gen'
 
@@ -112,11 +113,9 @@ function contentToStreamBlocks(content: string): StreamBlock[] {
 }
 
 // Convert text with `inline code` backticks to Tiptap content nodes
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function textToContent(text: string): any[] {
+function textToContent(text: string): JSONContent[] {
   const parts = text.split(/(`[^`]+`)/)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const nodes: any[] = []
+  const nodes: JSONContent[] = []
   for (const part of parts) {
     if (!part) continue
     if (part.startsWith('`') && part.endsWith('`')) {


### PR DESCRIPTION
Use Tiptap's exported JSONContent type for node arrays instead of any. Removes two eslint-disable comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
