### PR TITLE
fix: reset CommandPalette selected in onChange, not effect

### DIFF
--- a/src/CommandPalette.tsx
+++ b/src/CommandPalette.tsx
@@ -26,10 +26,6 @@ export function CommandPalette({ commands, onClose }: Props) {
     inputRef.current?.focus()
   }, [])
 
-  useEffect(() => {
-    setSelected(0)
-  }, [query])
-
   const run = (cmd: Command) => {
     onClose()
     cmd.action()
@@ -51,7 +47,7 @@ export function CommandPalette({ commands, onClose }: Props) {
             ref={inputRef}
             className="cmd-palette-input"
             value={query}
-            onChange={e => setQuery(e.target.value)}
+            onChange={e => { setQuery(e.target.value); setSelected(0) }}
             onKeyDown={e => {
               if (e.key === 'Escape') onClose()
               if (e.key === 'ArrowDown') { e.preventDefault(); setSelected(i => Math.min(i + 1, filtered.length - 1)) }


### PR DESCRIPTION
Replace a setState-in-effect anti-pattern with a direct state update in the query onChange handler. Avoids one render cycle and satisfies react-hooks/set-state-in-effect.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
