### PR TITLE
fix: capture completion time in useState initializer

### DIFF
--- a/src/components/TaskSummary.tsx
+++ b/src/components/TaskSummary.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import type { AgentTask } from '../types'
 
 /** Summary card shown in chat when all tasks are complete */
@@ -6,6 +6,9 @@ export const TaskSummary = memo(({ tasks, startTime }: {
   tasks: AgentTask[]
   startTime?: string
 }) => {
+  // Capture completion time once when the component first mounts
+  // (component only renders once all tasks are complete)
+  const [completedAt] = useState(() => Date.now())
   const complete = tasks.filter(t => t.status === 'complete')
   if (complete.length === 0 || complete.length < tasks.length) return null
 
@@ -19,7 +22,7 @@ export const TaskSummary = memo(({ tasks, startTime }: {
   const maxCount = Math.max(...Object.values(agentCounts), 1)
 
   const elapsed = startTime
-    ? Math.round((Date.now() - new Date(startTime).getTime()) / 60000)
+    ? Math.round((completedAt - new Date(startTime).getTime()) / 60000)
     : null
 
   return (


### PR DESCRIPTION
Date.now() in render body violates purity and would recompute elapsed on every re-render. Since this component only renders once all tasks are complete and the completion moment is fixed, capture it once via useState lazy initializer — stable and satisfies react-hooks/purity.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
