### PR TITLE
fix: hoist handleStarter before effect in HomePage

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { BlobAvatar } from './blob-avatar'
 import { MarkupLogo } from './MarkupLogo'
 import { listSessions, createSession, deleteSession } from './lib/session-store'
@@ -187,17 +187,17 @@ export function HomePage({ onSelect, onSignOut, demoMode, onDemoConsumed }: Prop
       .finally(() => setLoading(false))
   }, [])
 
+  const handleStarter = useCallback(async (starter: Starter) => {
+    const session = await createSession(starter.title, starter.template)
+    onSelect(session, starter.agents)
+  }, [onSelect])
+
   useEffect(() => {
     if (demoMode) {
       onDemoConsumed?.()
       handleStarter(DEMO_STARTER)
     }
   }, [demoMode]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleStarter = async (starter: Starter) => {
-    const session = await createSession(starter.title, starter.template)
-    onSelect(session, starter.agents)
-  }
 
   const handleResumeSession = (session: Session) => {
     onSelect(session, [])


### PR DESCRIPTION
Wrap handleStarter in useCallback and move above the demoMode effect to avoid forward-reference lint error.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
