### PR TITLE
chore: remove unused direct deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@opentelemetry/sdk-trace-node": "^2.6.0",
         "@paper-design/shaders-react": "^0.0.72",
         "@posthog/react": "^1.8.2",
-        "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
@@ -40,7 +39,6 @@
         "dompurify": "^3.3.3",
         "framer-motion": "^12.38.0",
         "highlight.js": "^11.11.1",
-        "json-stringify-pretty-compact": "^4.0.0",
         "lucide-react": "^1.7.0",
         "posthog-js": "^1.363.0",
         "radix-ui": "^1.4.3",
@@ -48,7 +46,6 @@
         "react-dom": "^19.2.0",
         "simplex-noise": "^4.0.3",
         "streamdown": "^2.5.0",
-        "use-debounce": "^10.1.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -9977,12 +9974,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-stringify-pretty-compact": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
-      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
       "license": "MIT"
     },
     "node_modules/json5": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@opentelemetry/sdk-trace-node": "^2.6.0",
     "@paper-design/shaders-react": "^0.0.72",
     "@posthog/react": "^1.8.2",
-    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
@@ -43,7 +42,6 @@
     "dompurify": "^3.3.3",
     "framer-motion": "^12.38.0",
     "highlight.js": "^11.11.1",
-    "json-stringify-pretty-compact": "^4.0.0",
     "lucide-react": "^1.7.0",
     "posthog-js": "^1.363.0",
     "radix-ui": "^1.4.3",
@@ -51,7 +49,6 @@
     "react-dom": "^19.2.0",
     "simplex-noise": "^4.0.3",
     "streamdown": "^2.5.0",
-    "use-debounce": "^10.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Three deps that are never imported in src/:
- @radix-ui/react-collapsible (still transitively pulled by radix-ui)
- use-debounce (still transitively pulled by @tambo-ai/react)
- json-stringify-pretty-compact (fully unused, now removed from lockfile)

No runtime code change; just cleanup of package.json.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
