### PR TITLE
fix: satisfy exhaustive-deps in useKeyboardShortcuts

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -9,20 +9,22 @@ interface ShortcutActions {
 }
 
 export function useKeyboardShortcuts(actions: ShortcutActions) {
+  const { newDoc, toggleCommandPalette, toggleSettings, toggleSidebar, togglePause } = actions
+
   // Use ref for togglePause to avoid stale closure issues
-  const togglePauseRef = useRef(actions.togglePause)
-  useEffect(() => { togglePauseRef.current = actions.togglePause })
+  const togglePauseRef = useRef(togglePause)
+  useEffect(() => { togglePauseRef.current = togglePause })
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey
-      if (mod && e.key === 'n') { e.preventDefault(); actions.newDoc() }
-      if (mod && e.key === 'k') { e.preventDefault(); actions.toggleCommandPalette() }
-      if (mod && e.key === ',') { e.preventDefault(); actions.toggleSettings() }
-      if (mod && e.key === '\\') { e.preventDefault(); actions.toggleSidebar() }
+      if (mod && e.key === 'n') { e.preventDefault(); newDoc() }
+      if (mod && e.key === 'k') { e.preventDefault(); toggleCommandPalette() }
+      if (mod && e.key === ',') { e.preventDefault(); toggleSettings() }
+      if (mod && e.key === '\\') { e.preventDefault(); toggleSidebar() }
       if (mod && e.shiftKey && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); togglePauseRef.current() }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [actions.newDoc, actions.toggleCommandPalette, actions.toggleSettings, actions.toggleSidebar])
+  }, [newDoc, toggleCommandPalette, toggleSettings, toggleSidebar])
 }


### PR DESCRIPTION
Destructure actions at hook top; the effect depends on the stable function references rather than property access on a containing object. Removes the last lint warning.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/172" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
