### PR TITLE
fix: sync mirror refs in effects in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,7 @@ function App() {
       }, 3000)
     },
   })
-  editorRef.current = editor
+  useEffect(() => { editorRef.current = editor })
 
   useEffect(() => {
     if (editor) lastDocSnapshot.current = editor.getText()
@@ -150,13 +150,13 @@ function App() {
   const [messages, setMessages] = useState<import('./types').Message[]>([])
   const [input, setInput] = useState('')
   const messagesRef = useRef(messages)
-  messagesRef.current = messages
+  useEffect(() => { messagesRef.current = messages })
   const lastProcessedMsg = useRef(0)
 
   // Task state
   const [tasks, setTasks] = useState<AgentTask[]>([])
   const tasksRef = useRef(tasks)
-  tasksRef.current = tasks
+  useEffect(() => { tasksRef.current = tasks })
   const [workPlan, setWorkPlan] = useState<{ presetId: string; presetTitle: string; tasks: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor' | 'order'>[] } | null>(null)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const pendingStarterRef = useRef<any>(null)
@@ -360,7 +360,7 @@ function App() {
       return next
     })
   }, [orchestratorRef, setAgentStates])
-  togglePauseRef.current = handleTogglePause
+  useEffect(() => { togglePauseRef.current = handleTogglePause })
 
   // Legal pages -- accessible without auth
   if (window.location.pathname === '/privacy') return <Suspense><LegalPage page="privacy" /></Suspense>


### PR DESCRIPTION
Four 'mirror state to ref' assignments in App.tsx happened during render body, violating react-hooks/refs. Wrap each in a commit-phase effect. Refs are consumed by orchestrator callbacks and timers, so effect-phase updates are sufficient.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
