### PR TITLE
fix: capture storage instead of aliasing this in agent-cursor

### DIFF
--- a/src/agent-cursor.ts
+++ b/src/agent-cursor.ts
@@ -124,14 +124,14 @@ export const AgentCursors = Extension.create({
   },
 
   addProseMirrorPlugins() {
-    const ext = this
+    const storage = this.storage
 
     return [
       new Plugin({
         key: agentCursorKey,
         props: {
           decorations(state) {
-            const cursors = ext.storage.cursors as AgentCursorState[]
+            const cursors = storage.cursors as AgentCursorState[]
             if (cursors.length === 0) return DecorationSet.empty
 
             const decorations: Decoration[] = []


### PR DESCRIPTION
The only use of the 'ext = this' alias was to access this.storage.cursors. Capture storage directly to avoid the @typescript-eslint/no-this-alias warning.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
