### PR TITLE
fix: unexport STARTERS in TemplatePickerModal

### DIFF
--- a/src/TemplatePickerModal.tsx
+++ b/src/TemplatePickerModal.tsx
@@ -18,7 +18,7 @@ interface Starter {
   agents: AgentConfig[]
 }
 
-export const STARTERS: Starter[] = [
+const STARTERS: Starter[] = [
   {
     id: 'blank',
     title: 'Blank Canvas',


### PR DESCRIPTION
STARTERS is exported but not imported outside the file (HomePage and HomeDashboard each define their own local STARTERS). Removing the export lets the file export only components, satisfying react-refresh/only-export-components.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
