### PR TITLE
refactor: extract AGENT_PRESETS and api-key cache

### DIFF
--- a/src/AgentConfigurator.tsx
+++ b/src/AgentConfigurator.tsx
@@ -1,55 +1,11 @@
 import { useState } from 'react'
 import { BlobAvatar } from './blob-avatar'
+import { AGENT_PRESETS as PRESETS } from './lib/agent-presets'
 import type { AgentConfig } from './types'
-
-const PRESETS: AgentConfig[] = [
-  {
-    name: 'Aiden',
-    description: 'Architecture, specs, and system design',
-    persona: 'You are Aiden, a collaborative AI agent who writes with technical precision. You think in systems, APIs, data models, and implementation trade-offs. You add concrete substance to documents: specific protocols, data flows, component boundaries, failure modes, and performance constraints. You turn vague ideas into buildable specifications.',
-    color: '#30d158',
-    owner: 'You',
-  },
-  {
-    name: 'Nova',
-    description: 'Product strategy and user needs',
-    persona: 'You are Nova, a collaborative AI agent who writes from the user\'s perspective. You think in user journeys, adoption curves, market positioning, and behavioral psychology. You challenge assumptions by asking "who benefits?" and "what breaks?". You add user scenarios, edge cases, adoption risks, and competitive framing.',
-    color: '#ff6961',
-    owner: 'You',
-  },
-  {
-    name: 'Lex',
-    description: 'Legal, compliance, and risk',
-    persona: 'You are Lex, a collaborative AI agent who writes with legal precision. You spot regulatory risks, privacy gaps, contractual ambiguity, and compliance failures. You flag liabilities before they become problems. Your prose is exact and cautious — every qualifier earns its place.',
-    color: '#64d2ff',
-    owner: 'You',
-  },
-  {
-    name: 'Mira',
-    description: 'Design, UX, and user advocacy',
-    persona: 'You are Mira, a collaborative AI agent who advocates for the end user. You think in user flows, visual hierarchy, accessibility, and interaction cost. You question complexity that hurts usability. When you see a feature without a user story, you write one. Your writing is visual — you describe what users see and do, not abstract principles.',
-    color: '#ffd60a',
-    owner: 'You',
-  },
-]
 
 interface Props {
   agents: AgentConfig[]
   onChange: (agents: AgentConfig[]) => void
-}
-
-const API_KEY_STORAGE_KEY = 'collab-gemini-api-key'
-let _cachedApiKey: string | null = null
-
-export function getStoredApiKey(): string {
-  if (_cachedApiKey !== null) return _cachedApiKey
-  _cachedApiKey = localStorage.getItem(API_KEY_STORAGE_KEY) || ''
-  return _cachedApiKey
-}
-
-// Invalidate cache when key is updated
-export function invalidateApiKeyCache(): void {
-  _cachedApiKey = null
 }
 
 export function AgentConfigurator({ agents, onChange }: Props) {
@@ -146,4 +102,3 @@ export function AgentConfigurator({ agents, onChange }: Props) {
   )
 }
 
-export { PRESETS as AGENT_PRESETS }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { AgentCursors } from './agent-cursor'
 import { DocMinimap } from './doc-minimap'
 import { Sidebar } from './Sidebar'
 import { CommandPalette } from './CommandPalette'
-import { invalidateApiKeyCache } from './AgentConfigurator'
+import { invalidateApiKeyCache } from './lib/api-key-cache'
 import { loadUserSettings, saveGeminiApiKey } from './lib/settings-store'
 
 // Lazy-loaded components (not needed on initial render)

--- a/src/AwakenSequence.tsx
+++ b/src/AwakenSequence.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { BlobAvatar } from './blob-avatar'
 import { MarkupLogo } from './MarkupLogo'
-import { AGENT_PRESETS } from './AgentConfigurator'
+import { AGENT_PRESETS } from './lib/agent-presets'
 
 interface Props {
   onComplete: () => void

--- a/src/ExperimentControls.tsx
+++ b/src/ExperimentControls.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { ExperimentSettings } from './types'
 import { DEFAULT_EXPERIMENTS } from './types'
-import { AGENT_PRESETS } from './AgentConfigurator'
+import { AGENT_PRESETS } from './lib/agent-presets'
 
 interface Props {
   settings: ExperimentSettings

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -4,7 +4,7 @@ import { MarkupLogo } from './MarkupLogo'
 import { listSessions, createSession, deleteSession } from './lib/session-store'
 import { DOC_TEMPLATES } from './templates'
 import type { Session, DocTemplate, AgentConfig } from './types'
-import { AGENT_PRESETS } from './AgentConfigurator'
+import { AGENT_PRESETS } from './lib/agent-presets'
 interface Starter {
   id: string
   title: string

--- a/src/TemplatePickerModal.tsx
+++ b/src/TemplatePickerModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { AGENT_PRESETS } from './AgentConfigurator'
+import { AGENT_PRESETS } from './lib/agent-presets'
 import { supabase } from './lib/supabase'
 import type { AgentConfig, DocTemplate } from './types'
 

--- a/src/__tests__/agent-api.test.ts
+++ b/src/__tests__/agent-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Mock AgentConfigurator before importing agent
-vi.mock('../AgentConfigurator', () => ({
+// Mock the api key cache before importing agent
+vi.mock('../lib/api-key-cache', () => ({
   getStoredApiKey: vi.fn(() => null),
 }))
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,7 +17,7 @@ export class AgentError extends Error {
   }
 }
 
-import { getStoredApiKey } from './AgentConfigurator'
+import { getStoredApiKey } from './lib/api-key-cache'
 
 // All API calls go through the server-side proxy which uses the Vercel AI SDK.
 const API_URL = '/api/gemini'

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -1,5 +1,5 @@
 import type { AgentConfig, DocTemplate, Session } from '../types'
-import { AGENT_PRESETS } from '../AgentConfigurator'
+import { AGENT_PRESETS } from '../lib/agent-presets'
 
 interface Starter {
   id: string

--- a/src/lib/agent-presets.ts
+++ b/src/lib/agent-presets.ts
@@ -1,0 +1,32 @@
+import type { AgentConfig } from '../types'
+
+export const AGENT_PRESETS: AgentConfig[] = [
+  {
+    name: 'Aiden',
+    description: 'Architecture, specs, and system design',
+    persona: 'You are Aiden, a collaborative AI agent who writes with technical precision. You think in systems, APIs, data models, and implementation trade-offs. You add concrete substance to documents: specific protocols, data flows, component boundaries, failure modes, and performance constraints. You turn vague ideas into buildable specifications.',
+    color: '#30d158',
+    owner: 'You',
+  },
+  {
+    name: 'Nova',
+    description: 'Product strategy and user needs',
+    persona: 'You are Nova, a collaborative AI agent who writes from the user\'s perspective. You think in user journeys, adoption curves, market positioning, and behavioral psychology. You challenge assumptions by asking "who benefits?" and "what breaks?". You add user scenarios, edge cases, adoption risks, and competitive framing.',
+    color: '#ff6961',
+    owner: 'You',
+  },
+  {
+    name: 'Lex',
+    description: 'Legal, compliance, and risk',
+    persona: 'You are Lex, a collaborative AI agent who writes with legal precision. You spot regulatory risks, privacy gaps, contractual ambiguity, and compliance failures. You flag liabilities before they become problems. Your prose is exact and cautious — every qualifier earns its place.',
+    color: '#64d2ff',
+    owner: 'You',
+  },
+  {
+    name: 'Mira',
+    description: 'Design, UX, and user advocacy',
+    persona: 'You are Mira, a collaborative AI agent who advocates for the end user. You think in user flows, visual hierarchy, accessibility, and interaction cost. You question complexity that hurts usability. When you see a feature without a user story, you write one. Your writing is visual — you describe what users see and do, not abstract principles.',
+    color: '#ffd60a',
+    owner: 'You',
+  },
+]

--- a/src/lib/api-key-cache.ts
+++ b/src/lib/api-key-cache.ts
@@ -1,0 +1,13 @@
+const API_KEY_STORAGE_KEY = 'collab-gemini-api-key'
+let _cachedApiKey: string | null = null
+
+export function getStoredApiKey(): string {
+  if (_cachedApiKey !== null) return _cachedApiKey
+  _cachedApiKey = localStorage.getItem(API_KEY_STORAGE_KEY) || ''
+  return _cachedApiKey
+}
+
+// Invalidate cache when key is updated
+export function invalidateApiKeyCache(): void {
+  _cachedApiKey = null
+}

--- a/src/lib/image-gen.ts
+++ b/src/lib/image-gen.ts
@@ -1,4 +1,4 @@
-import { getStoredApiKey } from '../AgentConfigurator'
+import { getStoredApiKey } from './api-key-cache'
 
 export async function generateImage(prompt: string): Promise<{ dataUrl: string, caption?: string } | null> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }


### PR DESCRIPTION
AgentConfigurator.tsx exported a component plus three data/utility exports, tripping react-refresh/only-export-components. Move the data (AGENT_PRESETS) and the cache helpers (getStoredApiKey, invalidateApiKeyCache) to dedicated lib modules. Updated all importers and the test mock path. No behavior change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
