### PR TITLE
fix: narrow any in vite.config gemini-image middleware

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -140,8 +140,12 @@ export default defineConfig(({ mode }) => {
                 }),
               })
 
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const data: any = await apiRes.json()
+              const data = await apiRes.json() as {
+                error?: { message?: string; code?: number }
+                candidates?: Array<{
+                  content?: { parts?: Array<{ inlineData?: { data: string; mimeType?: string }; text?: string }> }
+                }>
+              }
 
               if (!apiRes.ok) {
                 res.writeHead(apiRes.status, { 'Content-Type': 'application/json' })


### PR DESCRIPTION
Replace the eslint-disable'd any cast with a narrow type describing the Gemini image response. Cleaner for the fields we access.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
