### PR TITLE
perf: split tambo and radix into vendor chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -208,6 +208,8 @@ export default defineConfig(({ mode }) => {
             'vendor-shaders': ['@paper-design/shaders-react'],
             'vendor-posthog': ['posthog-js'],
             'vendor-framer': ['framer-motion'],
+            'vendor-tambo': ['@tambo-ai/react', '@tambo-ai/react-ui-base', '@tambo-ai/typescript-sdk'],
+            'vendor-radix': ['@radix-ui/react-dropdown-menu', '@radix-ui/react-popover', '@radix-ui/react-slot', 'radix-ui'],
           },
         },
       },


### PR DESCRIPTION
Main bundle was 1.58 MB (469 KB gzipped); tambo libs pulled into the app index. Split them into their own vendor-tambo and vendor-radix chunks. Main bundle now 877 KB (272 KB gzipped), each cached separately. Removes the chunk-size warning from every build.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
