### PR TITLE
fix: og:url trailing slash matches canonical

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://markup.so" />
+    <meta property="og:url" content="https://markup.so/" />
     <meta property="og:title" content="Markup — Every draft reviewed by four experts" />
     <meta property="og:description" content="AI agents that read your docs and push back on what you missed. Engineering, product, legal, and design perspectives in real time." />
     <meta property="og:site_name" content="Markup" />


### PR DESCRIPTION
Canonical is https://markup.so/ but og:url was https://markup.so (no trailing slash). Match them so link previews and search engines see one URL.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
