### PR TITLE
fix: narrow pendingStarterRef type in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,8 +158,7 @@ function App() {
   const tasksRef = useRef(tasks)
   useEffect(() => { tasksRef.current = tasks })
   const [workPlan, setWorkPlan] = useState<{ presetId: string; presetTitle: string; tasks: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor' | 'order'>[] } | null>(null)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const pendingStarterRef = useRef<any>(null)
+  const pendingStarterRef = useRef<{ id: string; title: string; template: import('./types').DocTemplate; agents: import('./types').AgentConfig[] } | null>(null)
 
   // Stable orchestrator ref -- shared between useSession and useOrchestrator
   const orchestratorRef = useRef<ReturnType<typeof import('./orchestrator').createOrchestrator> | null>(null)


### PR DESCRIPTION
Use the actual starter shape in the ref type. Removes the eslint-disable and gets real type checking on the ref.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
