### PR TITLE
perf: split markdown libs into vendor chunk

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -210,6 +210,7 @@ export default defineConfig(({ mode }) => {
             'vendor-framer': ['framer-motion'],
             'vendor-tambo': ['@tambo-ai/react', '@tambo-ai/react-ui-base', '@tambo-ai/typescript-sdk'],
             'vendor-radix': ['@radix-ui/react-dropdown-menu', '@radix-ui/react-popover', '@radix-ui/react-slot', 'radix-ui'],
+            'vendor-markdown': ['streamdown', 'highlight.js', 'dompurify'],
           },
         },
       },


### PR DESCRIPTION
Main bundle dropped from 877 KB to 371 KB (272 KB gzipped to 116 KB). Markdown libs (streamdown, highlight.js, dompurify) live in their own cached vendor-markdown chunk.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
