### PR TITLE
fix: guard localStorage in getStoredApiKey

### DIFF
--- a/src/lib/api-key-cache.ts
+++ b/src/lib/api-key-cache.ts
@@ -3,7 +3,12 @@ let _cachedApiKey: string | null = null
 
 export function getStoredApiKey(): string {
   if (_cachedApiKey !== null) return _cachedApiKey
-  _cachedApiKey = localStorage.getItem(API_KEY_STORAGE_KEY) || ''
+  try {
+    _cachedApiKey = localStorage.getItem(API_KEY_STORAGE_KEY) || ''
+  } catch {
+    // localStorage may be unavailable (e.g. private mode, disabled cookies)
+    _cachedApiKey = ''
+  }
   return _cachedApiKey
 }
 


### PR DESCRIPTION
Accessing localStorage throws in Firefox private mode and some embedded contexts. getStoredApiKey is called on every agent request, so an uncaught throw would break all inference. Wrap with try/catch; empty-string fallback matches existing null-key behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
