### PR TITLE
chore: disable fast-refresh rule in src/components/tambo

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,4 +31,12 @@ export default defineConfig([
       ],
     },
   },
+  {
+    // Tambo-generated components (via `npx tambo add`) mix helper hooks with
+    // component exports by design. Silence the fast-refresh rule for them.
+    files: ['src/components/tambo/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])


### PR DESCRIPTION
Tambo-generated components (via npx tambo add) co-locate helper hooks with component exports by design. Silence react-refresh/only-export-components for that directory so the lint signal reflects real issues in app code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
