### PR TITLE
refactor: extract useAuth to lib/auth-context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { saveDocument, updateSessionTitle, saveChatMessage, saveAgentTasks, upda
 import { identify, events } from './lib/analytics'
 import { TamboProvider } from '@tambo-ai/react'
 import { tamboComponents } from './lib/tambo'
-import { useAuth } from './lib/auth'
+import { useAuth } from './lib/auth-context'
 import type { Session, AgentState, TimelineEntry, ExperimentSettings, AgentTask, TaskActionPayload } from './types'
 import { DEFAULT_EXPERIMENTS } from './types'
 // ColorPanels removed -- home dashboard no longer uses shader background

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense } from 'react'
 const ColorPanels = lazy(() => import('@paper-design/shaders-react').then(m => ({ default: m.ColorPanels })))
 import { MarkupLogo } from './MarkupLogo'
-import { useAuth } from './lib/auth'
+import { useAuth } from './lib/auth-context'
 
 export function LoginPage() {
   const { signInWithGoogle } = useAuth()

--- a/src/lib/auth-context.ts
+++ b/src/lib/auth-context.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from 'react'
+import type { User } from '@supabase/supabase-js'
+
+export interface AuthContextValue {
+  user: User | null
+  loading: boolean
+  providerToken: string | null
+  signInWithGoogle: () => Promise<void>
+  signOut: () => Promise<void>
+}
+
+export const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  loading: true,
+  providerToken: null,
+  signInWithGoogle: async () => {},
+  signOut: async () => {},
+})
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,26 +1,7 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { supabase } from './supabase'
 import type { User } from '@supabase/supabase-js'
-
-interface AuthContextValue {
-  user: User | null
-  loading: boolean
-  providerToken: string | null
-  signInWithGoogle: () => Promise<void>
-  signOut: () => Promise<void>
-}
-
-const AuthContext = createContext<AuthContextValue>({
-  user: null,
-  loading: true,
-  providerToken: null,
-  signInWithGoogle: async () => {},
-  signOut: async () => {},
-})
-
-export function useAuth() {
-  return useContext(AuthContext)
-}
+import { AuthContext } from './auth-context'
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)


### PR DESCRIPTION
Move context + useAuth hook out of auth.tsx so the file exports only the AuthProvider component. Removes the last structural fast-refresh lint.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
