### PR TITLE
a11y: use button for reasoning-chain disclosure

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -996,6 +996,13 @@
   gap: 4px;
   color: var(--text-tertiary);
   font-size: 12px;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
 }
 
 .reasoning-chevron {

--- a/src/components/ReasoningChain.tsx
+++ b/src/components/ReasoningChain.tsx
@@ -3,13 +3,19 @@ import { useState } from 'react'
 export function ReasoningChain({ steps }: { steps: string[] }) {
   const [expanded, setExpanded] = useState(false)
   return (
-    <div className={`reasoning-chain ${expanded ? 'expanded' : ''}`} onClick={() => setExpanded(!expanded)}>
-      <div className="reasoning-header">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={`reasoning-chevron ${expanded ? 'open' : ''}`}>
+    <div className={`reasoning-chain ${expanded ? 'expanded' : ''}`}>
+      <button
+        type="button"
+        className="reasoning-header"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Hide reasoning steps' : 'Show reasoning steps'}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={`reasoning-chevron ${expanded ? 'open' : ''}`} aria-hidden="true">
           <polyline points="9 18 15 12 9 6" />
         </svg>
         <span className="reasoning-label">{steps.length} {steps.length === 1 ? 'step' : 'steps'}</span>
-      </div>
+      </button>
       {expanded && (
         <div className="reasoning-steps">
           {steps.map((step, i) => (


### PR DESCRIPTION
Old: clickable div without keyboard/screen-reader affordances. New: a real button with aria-expanded and aria-label. Reset default button chrome in CSS so visuals match.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
