### PR TITLE
chore: silence react-hooks/refs for buildCommands call

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -581,7 +581,10 @@ function App() {
         <CommandPalette
           onClose={() => setShowCommandPalette(false)}
           commands={buildCommands(
+            // editorRef is dereferenced only inside command action callbacks, never during render.
+            // eslint-disable-next-line react-hooks/refs
             { activeSession, activeAgents, agentsPaused, sidebarCollapsed, isLocalhost, hasUser: !!user, editorRef: editorRef as React.RefObject<{ getText: () => string } | null> },
+            // eslint-disable-next-line react-hooks/refs
             { setShowTemplatePicker, handleTogglePause, setShowConfigurator, setSidebarCollapsed, setShowExperiments, resetToHome, setMessages, toast, signOut, uid, now },
           )}
         />


### PR DESCRIPTION
editorRef is dereferenced only inside command action callbacks (Export Markdown etc.), never during render. Document the intent and silence the false-positive lint so the signal is clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
