### PR TITLE
chore: gate supabase env-var warn behind DEV

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,7 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 const url = import.meta.env.VITE_SUPABASE_URL as string
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
-if (!url || !key) {
+if (import.meta.env.DEV && (!url || !key)) {
   console.warn(
     '[supabase] Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY',
   )


### PR DESCRIPTION
## Summary
- The `console.warn` for missing `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` was firing in production builds too. Env vars are guaranteed at deploy time, so the warning is just noise.
- Wraps the warning in `import.meta.env.DEV` so it only fires during local development when actually useful.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
