### PR TITLE
a11y: label task-checklist expand button and hide decorative chevron

### DIFF
--- a/src/components/TaskChecklist.tsx
+++ b/src/components/TaskChecklist.tsx
@@ -12,12 +12,21 @@ export const TaskChecklist = memo(({ tasks }: { tasks: AgentTask[] }) => {
 
   return (
     <div className="task-checklist">
-      <button className="task-checklist-header" onClick={() => setExpanded(!expanded)}>
+      <button
+        type="button"
+        className="task-checklist-header"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-label={expanded ? 'Collapse task list' : 'Expand task list'}
+      >
         <span className="task-checklist-label">Tasks</span>
         <span className={`task-checklist-count ${allDone ? 'task-checklist-done' : ''}`}>
           {complete}/{tasks.length}
         </span>
-        <span className={`task-checklist-chevron ${expanded ? 'task-checklist-expanded' : ''}`}>
+        <span
+          className={`task-checklist-chevron ${expanded ? 'task-checklist-expanded' : ''}`}
+          aria-hidden="true"
+        >
           &#x25B8;
         </span>
       </button>


### PR DESCRIPTION
## Summary
- The collapsible task-list header in `TaskChecklist.tsx` had no accessible label or `aria-expanded` state — assistive tech would announce "Tasks 0/3 ▸" with no hint that it's interactive.
- Adds `type="button"`, `aria-expanded`, and a state-aware `aria-label`.
- Marks the chevron glyph `aria-hidden="true"` since it's decorative.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] No visual change

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
