### PR TITLE
a11y: label sidebar clear-search button and hide its svg

### DIFF
--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -136,8 +136,13 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
               onBlur={() => { if (!search) setSearchOpen(false) }}
             />
             {search && (
-              <button className="sidebar-search-clear" onClick={() => { setSearch(''); setSearchOpen(false) }}>
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <button
+                type="button"
+                className="sidebar-search-clear"
+                onClick={() => { setSearch(''); setSearchOpen(false) }}
+                aria-label="Clear search"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <line x1="18" y1="6" x2="6" y2="18" />
                   <line x1="6" y1="6" x2="18" y2="18" />
                 </svg>


### PR DESCRIPTION
## Summary
- The X button that clears the sidebar search input had no accessible name — screen readers would announce it as an unlabeled button.
- Adds `type="button"`, `aria-label="Clear search"`, and `aria-hidden` on the inner svg.
- Matches the pattern already used by the search-open button two lines below (`Sidebar.tsx:153`).

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] No visual change

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
