### PR TITLE
chore: add typecheck script for fast TS-only check

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Both agents receive the same document context and recent chat history on every t
 |--------|-------------|
 | `npm run dev` | Start Vite dev server with HMR at `localhost:5173` |
 | `npm run build` | Type-check + bundle for production (`dist/`) |
+| `npm run typecheck` | Type-check only (no bundle) |
 | `npm run preview` | Preview the production build locally |
 | `npm run lint` | Run ESLint across all source files |
 | `npm run test` | Run Vitest unit tests |

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- `npm run build` chains `tsc -b && vite build` — useful for CI but slow locally when you only want to check types.
- Adds a `typecheck` script that runs just `tsc -b`.
- Documents it in the README "Available Scripts" table.

## Test plan
- [x] `npm run typecheck` runs cleanly
- [x] `npm run build` still works (unchanged)

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
