### PR TITLE
fix: wrap app root in ErrorBoundary

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { Analytics } from '@vercel/analytics/react'
 import './index.css'
 import { AuthProvider } from './lib/auth.tsx'
 import { ToastProvider } from './components/Toast.tsx'
+import { ErrorBoundary } from './components/ErrorBoundary.tsx'
 import App from './App.tsx'
 
 const posthogKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY as string
@@ -15,25 +16,29 @@ const root = createRoot(document.getElementById('root')!)
 if (posthogKey) {
   root.render(
     <StrictMode>
-      <PostHogProvider apiKey={posthogKey} options={{ api_host: posthogHost, autocapture: false, capture_pageview: false, persistence: 'localStorage' }}>
-        <ToastProvider>
-          <AuthProvider>
-            <App />
-          </AuthProvider>
-        </ToastProvider>
-      </PostHogProvider>
-      <Analytics />
+      <ErrorBoundary>
+        <PostHogProvider apiKey={posthogKey} options={{ api_host: posthogHost, autocapture: false, capture_pageview: false, persistence: 'localStorage' }}>
+          <ToastProvider>
+            <AuthProvider>
+              <App />
+            </AuthProvider>
+          </ToastProvider>
+        </PostHogProvider>
+        <Analytics />
+      </ErrorBoundary>
     </StrictMode>,
   )
 } else {
   root.render(
     <StrictMode>
-      <ToastProvider>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </ToastProvider>
-      <Analytics />
+      <ErrorBoundary>
+        <ToastProvider>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </ToastProvider>
+        <Analytics />
+      </ErrorBoundary>
     </StrictMode>,
   )
 }


### PR DESCRIPTION
## Summary
- `ErrorBoundary` already wraps the editor and chat panels in `App.tsx`, but **nothing** catches crashes from `AuthProvider`, `ToastProvider`, the sidebar, session header, or App's own render.
- A throw during init currently unmounts React and leaves users with a blank dark screen and no recovery.
- Wraps the entire tree in `main.tsx` so those crashes route to the existing "Try again / Reload page" fallback UI.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] Inner `ErrorBoundary` instances in App.tsx still work as panel-level boundaries

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
