### PR TITLE
feat: render a pulse loader before the JS bundle hydrates

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,38 @@
     <!-- iMessage / Apple -->
     <meta property="og:image:secure_url" content="https://markup.so/og-image.png" />
 
+    <style>
+      #initial-loader {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0e0e0e;
+        pointer-events: none;
+      }
+      .initial-loader-pulse {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.5);
+        animation: initial-loader-pulse 1.4s ease-in-out infinite;
+      }
+      @keyframes initial-loader-pulse {
+        0%, 100% { opacity: 0.25; transform: scale(0.85); }
+        50% { opacity: 1; transform: scale(1.15); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .initial-loader-pulse { animation: none; opacity: 0.5; }
+      }
+    </style>
   </head>
   <body style="margin:0;background:#0e0e0e">
-    <div id="root"></div>
+    <div id="root">
+      <div id="initial-loader" aria-hidden="true">
+        <div class="initial-loader-pulse"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Users hitting the site previously saw a blank dark screen for the 1–2 seconds between HTML parse and the first React paint (the JS bundles total ~2.3 MB across vendor chunks).
- Adds a tiny inline `<style>` and a single pulsing dot inside `#root` so there's at least a "page is alive" signal.
- React's `root.render(...)` replaces `#root`'s children on first render, so the loader is removed automatically once the app mounts — no JS hook or unmount logic required.
- The animation is disabled under `prefers-reduced-motion`.

## Test plan
- [x] `npm run build` succeeds; the loader is present in `dist/index.html`
- [x] Visible dot appears immediately on page load and is replaced by the app once it mounts
- [x] No additional bytes downloaded (everything is inline)

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
