### PR TITLE
feat: add ?view=1 spectator mode for read-only session sharing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,6 +110,29 @@
   color: var(--color-danger);
 }
 
+/* Read-only spectator badge — appears where save-status would, with a subtle eye-ish feel */
+.header-view-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 8px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  flex-shrink: 0;
+  cursor: help;
+}
+
+/* Editor in view mode — softer caret-off affordance */
+.doc-editor-view {
+  caret-color: transparent;
+  user-select: text;
+}
+
 @keyframes savedFade {
   0% { opacity: 1; }
   70% { opacity: 1; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,11 @@ function App() {
   const { user, loading: authLoading, signOut, providerToken, signInWithGoogle } = useAuth()
   const { toast } = useToast()
 
+  // Read-only spectator mode: /s/:id?view=1 — doc is not editable and
+  // agents don't run. Lets a second human tail the session without the
+  // orchestrator fighting over writes.
+  const isViewMode = new URLSearchParams(window.location.search).has('view')
+
   // PostHog user identification (init handled by PostHogProvider in main.tsx)
   useEffect(() => {
     if (user) identify(user.id, { email: user.email })
@@ -59,8 +64,8 @@ function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(240)
   const [chatWidth, setChatWidth] = useState(340)
-  const [agentsPaused, setAgentsPaused] = useState(false)
-  const agentsPausedRef = useRef(false)
+  const [agentsPaused, setAgentsPaused] = useState(isViewMode)
+  const agentsPausedRef = useRef(isViewMode)
   const resizingRef = useRef<'sidebar' | 'chat' | null>(null)
   const [saveStatus, setSaveStatus] = useState<'saved' | 'saving' | 'idle'>('idle')
   const [showConfigurator, setShowConfigurator] = useState(false)
@@ -86,9 +91,10 @@ function App() {
       }),
     ],
     content: EMPTY_DOC,
+    editable: !isViewMode,
     editorProps: {
       attributes: {
-        class: 'doc-editor',
+        class: `doc-editor${isViewMode ? ' doc-editor-view' : ''}`,
       },
     },
     onUpdate: ({ editor: ed }) => {
@@ -413,6 +419,7 @@ function App() {
           onToggleConfigurator={() => setShowConfigurator(v => !v)}
           onAgentsChange={setActiveAgents}
           activeSessionRef={activeSessionRef}
+          isViewMode={isViewMode}
         />
       )}
       <div className="app-body">

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -18,6 +18,7 @@ interface SessionHeaderProps {
   onToggleConfigurator: () => void
   onAgentsChange: (agents: AgentConfig[]) => void
   activeSessionRef: React.RefObject<Session | null>
+  isViewMode?: boolean
 }
 
 export function SessionHeader({
@@ -32,17 +33,19 @@ export function SessionHeader({
   onToggleConfigurator,
   onAgentsChange,
   activeSessionRef,
+  isViewMode = false,
 }: SessionHeaderProps) {
   return (
     <>
       <div className="app-header">
         <div className="header-editor-zone">
           <span className="header-doc-title">{activeSession.title}</span>
-          {saveStatus === 'saving' && <span className="header-save-status">Saving...</span>}
-          {saveStatus === 'saved' && <span className="header-save-status saved">Saved</span>}
+          {isViewMode && <span className="header-view-badge" title="Read-only spectator link. Edits are disabled and agents are paused.">Viewing</span>}
+          {!isViewMode && saveStatus === 'saving' && <span className="header-save-status">Saving...</span>}
+          {!isViewMode && saveStatus === 'saved' && <span className="header-save-status saved">Saved</span>}
         </div>
         <div className="header-chat-zone" style={{ width: chatWidth + 4 }}>
-          <button
+          {!isViewMode && <button
             className={`header-pause-btn ${agentsPaused ? 'paused' : ''}`}
             onClick={onTogglePause}
             title={agentsPaused ? 'Resume agents' : 'Pause agents'}
@@ -58,7 +61,7 @@ export function SessionHeader({
                 <rect x="14" y="4" width="5" height="16" rx="1" />
               </svg>
             )}
-          </button>
+          </button>}
           <div className="header-participants">
             {activeAgents.map((agent, idx) => {
               const agentState = getAgentState(agent.name)


### PR DESCRIPTION
## Summary

Markup is single-user + multi-agent today. This PR is the first shippable step toward **multi-human + multi-agent**: a URL-param-gated read-only spectator mode that lets a second human tail a live session without writing.

When `?view=1` is in the URL:
- Tiptap editor mounts as `editable: false` (caret hidden via `.doc-editor-view` CSS, no input)
- `agentsPaused` starts `true` so `useOrchestrator` short-circuits (`agentsPausedRef.current` is checked before orchestrator creation at `useOrchestrator.ts:144`) — no agent actions fire for the observer
- Session header renders a "Viewing" pill instead of the save-status and pause button

No data-model changes, no server changes, no impact on existing single-user flows.

## Why this shape

Three lenses weighed in on how to evolve this toward genuine multi-human / multi-agent collab (design, social, engineering). The engineering lens ranked spectator mode as the lowest-risk visible unlock — zero data-model work, and it exercises the assumption that `agent-cursor.ts`'s multi-cursor infra is already the right substrate for showing additional humans later. Follow-ups queued:

1. A "Share read-only link" button in the session header
2. Live doc + chat streaming via Supabase Realtime (so the observer auto-updates)
3. Render observer presence back to the author (one human cursor → N human cursors)

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] `npm run lint` clean
- [x] Opening a session without `?view=1` is unchanged (editor editable, pause button visible)
- [x] Opening with `?view=1` shows the "Viewing" pill, hides the pause button, and blocks doc edits

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
