### PR TITLE
feat: add copy-read-only-link button to session header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -214,6 +214,27 @@
   line-height: 1;
 }
 
+/* Share read-only link — compact icon button matching pause-btn feel */
+.header-share-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  width: 26px;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-pill);
+  margin-right: 4px;
+  transition: color var(--duration-fast) ease, background var(--duration-fast) ease;
+}
+
+.header-share-btn:hover {
+  color: var(--text-primary);
+  background: var(--surface-3);
+}
+
 /* Add agent button — labeled pill */
 .header-add-agent {
   display: flex;

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -4,6 +4,7 @@ import { AgentConfigurator } from '../AgentConfigurator'
 import { AGENT_DESCRIPTIONS } from './AgentHoverCard'
 import { saveAgentPersonas } from '../lib/session-store'
 import { agentConfigsToPersonas } from '../lib/agent-personas'
+import { useToast } from '../lib/toast-context'
 import type { AgentConfig, AgentState, Session } from '../types'
 
 interface SessionHeaderProps {
@@ -35,6 +36,18 @@ export function SessionHeader({
   activeSessionRef,
   isViewMode = false,
 }: SessionHeaderProps) {
+  const { toast } = useToast()
+
+  const copyViewLink = async () => {
+    const url = `${window.location.origin}/s/${activeSession.id}?view=1`
+    try {
+      await navigator.clipboard.writeText(url)
+      toast({ type: 'success', message: 'Read-only link copied' })
+    } catch {
+      toast({ type: 'error', message: 'Failed to copy link' })
+    }
+  }
+
   return (
     <>
       <div className="app-header">
@@ -45,6 +58,18 @@ export function SessionHeader({
           {!isViewMode && saveStatus === 'saved' && <span className="header-save-status saved">Saved</span>}
         </div>
         <div className="header-chat-zone" style={{ width: chatWidth + 4 }}>
+          {!isViewMode && <button
+            type="button"
+            className="header-share-btn"
+            onClick={copyViewLink}
+            title="Copy a read-only view link for this session"
+            aria-label="Copy read-only link"
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.5 1.5" />
+              <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5" />
+            </svg>
+          </button>}
           {!isViewMode && <button
             className={`header-pause-btn ${agentsPaused ? 'paused' : ''}`}
             onClick={onTogglePause}


### PR DESCRIPTION
## Summary
Makes the `?view=1` spectator mode shipped in #206 actually usable. Adds a small link-icon button to `SessionHeader`; clicking copies `<origin>/s/<sessionId>?view=1` to the clipboard and toasts "Read-only link copied".

- The button is hidden in view mode itself (a spectator has no need to re-share their own view).
- Uses `navigator.clipboard` with a graceful error toast for Safari permission denials / insecure contexts.
- Button style mirrors the existing `.header-pause-btn` (26px pill).

Completes step 2 of the proposed roadmap in `docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md`. Live doc streaming (step 3) is the next merge.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] `npm run lint` clean
- [x] Click in an open session copies the URL and surfaces a success toast
- [x] Button hidden when loading with `?view=1`

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
