### PR TITLE
a11y: add type=&quot;button&quot; to 62 non-submit buttons

### DIFF
--- a/src/AgentConfigurator.tsx
+++ b/src/AgentConfigurator.tsx
@@ -57,7 +57,7 @@ export function AgentConfigurator({ agents, onChange }: Props) {
                     <span className="ac-field-label">System prompt</span>
                     <textarea value={a.persona} onChange={e => update(i, { persona: e.target.value })} rows={3} />
                   </label>
-                  <button className="ac-done-btn" onClick={() => setEditing(null)}>Done</button>
+                  <button type="button" className="ac-done-btn" onClick={() => setEditing(null)}>Done</button>
                 </div>
               ) : (
                 <div className="ac-view">
@@ -70,8 +70,8 @@ export function AgentConfigurator({ agents, onChange }: Props) {
                     <div className="ac-card-dot" style={{ background: a.color }} />
                   </div>
                   <div className="ac-card-actions">
-                    <button className="ac-btn" onClick={() => setEditing(i)}>Edit</button>
-                    {agents.length > 1 && <button className="ac-btn ac-btn-remove" onClick={() => remove(i)}>Remove</button>}
+                    <button type="button" className="ac-btn" onClick={() => setEditing(i)}>Edit</button>
+                    {agents.length > 1 && <button type="button" className="ac-btn ac-btn-remove" onClick={() => remove(i)}>Remove</button>}
                   </div>
                 </div>
               )}
@@ -85,7 +85,7 @@ export function AgentConfigurator({ agents, onChange }: Props) {
           <div className="ac-label">Add agent</div>
           <div className="ac-preset-grid">
             {availablePresets.map(pr => (
-              <button key={pr.name} className="ac-preset-card" onClick={() => addPreset(pr)}>
+              <button type="button" key={pr.name} className="ac-preset-card" onClick={() => addPreset(pr)}>
                 <BlobAvatar name={pr.name} size={24} color={pr.color} />
                 <div className="ac-preset-info">
                   <span className="ac-preset-name">{pr.name}</span>

--- a/src/CommandPalette.tsx
+++ b/src/CommandPalette.tsx
@@ -61,7 +61,7 @@ export function CommandPalette({ commands, onClose }: Props) {
           {filtered.length === 0 ? (
             <div className="cmd-palette-empty">No matching commands</div>
           ) : filtered.map((cmd, i) => (
-            <button
+            <button type="button"
               key={cmd.id}
               className={`cmd-palette-item ${i === selected ? 'cmd-palette-item-active' : ''}`}
               onClick={() => run(cmd)}

--- a/src/ExperimentControls.tsx
+++ b/src/ExperimentControls.tsx
@@ -44,8 +44,8 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
         <div className="exp-header">
           <h2 className="exp-title">Settings</h2>
           <div className="exp-header-actions">
-            <button className="exp-reset" onClick={resetAll}>Reset all</button>
-            <button className="exp-close" onClick={onClose}>
+            <button type="button" className="exp-reset" onClick={resetAll}>Reset all</button>
+            <button type="button" className="exp-close" onClick={onClose}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />
@@ -75,7 +75,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
                     spellCheck={false}
                     autoComplete="off"
                   />
-                  <button className="exp-key-toggle" onClick={() => setKeyVisible(v => !v)} title={keyVisible ? 'Hide' : 'Show'}>
+                  <button type="button" className="exp-key-toggle" onClick={() => setKeyVisible(v => !v)} title={keyVisible ? 'Hide' : 'Show'}>
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                       {keyVisible ? (
                         <><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" /><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" /><line x1="1" y1="1" x2="23" y2="23" /></>
@@ -90,7 +90,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
                     Used when no server key is configured.{' '}
                     <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener noreferrer">Get a key</a>
                   </span>
-                  <button
+                  <button type="button"
                     className="exp-key-save"
                     disabled={keySaving || keySaved}
                     onClick={() => {
@@ -112,7 +112,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
               {AGENT_PRESETS.map(p => {
                 const active = local.defaultAgentNames.includes(p.name)
                 return (
-                  <button
+                  <button type="button"
                     key={p.name}
                     className={`exp-agent-chip ${active ? 'exp-agent-active' : ''}`}
                     onClick={() => toggleAgent(p.name)}
@@ -131,7 +131,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
 
             <label className="exp-toggle-row">
               <span className="exp-label">Auto-activate on add</span>
-              <button
+              <button type="button"
                 className={`exp-toggle ${local.autoActivateOnAdd ? 'exp-toggle-on' : ''}`}
                 onClick={() => update('autoActivateOnAdd', !local.autoActivateOnAdd)}
               >
@@ -249,7 +249,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
               </div>
               <div className="exp-select-group">
                 {(['strict', 'fuzzy', 'always-end'] as const).map(opt => (
-                  <button
+                  <button type="button"
                     key={opt}
                     className={`exp-select-btn ${local.insertStrategy === opt ? 'exp-select-active' : ''}`}
                     onClick={() => update('insertStrategy', opt)}
@@ -262,7 +262,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
 
             <label className="exp-toggle-row">
               <span className="exp-label">Verbose logging</span>
-              <button
+              <button type="button"
                 className={`exp-toggle ${local.verboseLogging ? 'exp-toggle-on' : ''}`}
                 onClick={() => update('verboseLogging', !local.verboseLogging)}
               >

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -20,7 +20,7 @@ export function LoginPage() {
             <MarkupLogo height={20} className="home-nav-logo-img" />
           </div>
           <div className="home-nav-actions">
-            <button className="login-google-btn login-google-btn--nav" onClick={signInWithGoogle}>
+            <button type="button" className="login-google-btn login-google-btn--nav" onClick={signInWithGoogle}>
               Sign in
             </button>
           </div>
@@ -35,7 +35,7 @@ export function LoginPage() {
             AI agents that read your docs and push back on what you missed.
           </p>
           <div className="login-cta-row">
-            <button className="home-cta-primary" onClick={signInWithGoogle}>
+            <button type="button" className="home-cta-primary" onClick={signInWithGoogle}>
               Get started
             </button>
           </div>

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -109,7 +109,7 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
 
   if (collapsed) {
     return (
-      <button className="sidebar-expand-btn" onClick={onCollapse} title="Expand sidebar" aria-label="Expand sidebar">
+      <button type="button" className="sidebar-expand-btn" onClick={onCollapse} title="Expand sidebar" aria-label="Expand sidebar">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <polyline points="9 18 15 12 9 6" />
         </svg>
@@ -155,7 +155,7 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
               <MarkupLogo height={20} className="sidebar-brand-logo" />
             </span>
             {sessions.length > 3 && (
-              <button className="sidebar-search-btn" onClick={() => setSearchOpen(true)} title="Search documents" aria-label="Search documents">
+              <button type="button" className="sidebar-search-btn" onClick={() => setSearchOpen(true)} title="Search documents" aria-label="Search documents">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <circle cx="11" cy="11" r="8" />
                   <line x1="21" y1="21" x2="16.65" y2="16.65" />
@@ -199,7 +199,7 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
                       autoFocus
                     />
                   ) : (
-                    <button
+                    <button type="button"
                       className={`sidebar-doc-item ${s.id === activeSessionId ? 'active' : ''}`}
                       onClick={() => onSelect(s)}
                       onDoubleClick={() => { setRenamingId(s.id); setRenameValue(s.title) }}
@@ -252,19 +252,19 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
           {userMenuOpen && (
             <div className="sidebar-avatar-menu">
               <div className="sidebar-avatar-menu-name">{user?.user_metadata?.full_name || user?.email || 'Local user'}</div>
-              <button className="sidebar-avatar-menu-item" onClick={() => { setUserMenuOpen(false); onSettings?.() }}>Settings</button>
-              {onSignOut && <button className="sidebar-avatar-menu-item" onClick={onSignOut}>Sign out</button>}
+              <button type="button" className="sidebar-avatar-menu-item" onClick={() => { setUserMenuOpen(false); onSettings?.() }}>Settings</button>
+              {onSignOut && <button type="button" className="sidebar-avatar-menu-item" onClick={onSignOut}>Sign out</button>}
             </div>
           )}
         </div>
-        <button className="sidebar-new-btn" onClick={onNewDoc} aria-label="Create new document">
+        <button type="button" className="sidebar-new-btn" onClick={onNewDoc} aria-label="Create new document">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
           New document
         </button>
-        <button className="sidebar-collapse-btn" onClick={onCollapse} title="Collapse sidebar" aria-label="Collapse sidebar">
+        <button type="button" className="sidebar-collapse-btn" onClick={onCollapse} title="Collapse sidebar" aria-label="Collapse sidebar">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <polyline points="15 18 9 12 15 6" />
           </svg>
@@ -276,8 +276,8 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
           <div className="sidebar-confirm-dialog" onClick={e => e.stopPropagation()}>
             <p className="sidebar-confirm-text">Delete this document? This can't be undone.</p>
             <div className="sidebar-confirm-actions">
-              <button className="sidebar-confirm-cancel" onClick={() => setConfirmDelete(null)}>Cancel</button>
-              <button className="sidebar-confirm-delete" onClick={() => handleDelete(confirmDelete)}>Delete</button>
+              <button type="button" className="sidebar-confirm-cancel" onClick={() => setConfirmDelete(null)}>Cancel</button>
+              <button type="button" className="sidebar-confirm-delete" onClick={() => handleDelete(confirmDelete)}>Delete</button>
             </div>
           </div>
         </div>

--- a/src/TemplatePickerModal.tsx
+++ b/src/TemplatePickerModal.tsx
@@ -121,7 +121,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
         <div className="template-picker-header">
           {showDrivePicker ? (
             <>
-              <button className="template-picker-back" onClick={() => setShowDrivePicker(false)}>
+              <button type="button" className="template-picker-back" onClick={() => setShowDrivePicker(false)}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="15 18 9 12 15 6" />
                 </svg>
@@ -131,7 +131,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
           ) : (
             <span className="template-picker-title">New document</span>
           )}
-          <button className="template-picker-close" onClick={onClose}>
+          <button type="button" className="template-picker-close" onClick={onClose}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
@@ -143,7 +143,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
         ) : (
         <>
         <div className="template-picker-import">
-          <button
+          <button type="button"
             className="template-picker-import-btn"
             onClick={() => {
               if (!importAvailable) {
@@ -173,7 +173,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
         <div className="template-picker-divider" />
         <div className="template-picker-list">
           {STARTERS.map(s => (
-            <button
+            <button type="button"
               key={s.id}
               className="template-picker-item"
               onClick={() => onSelect(s)}
@@ -290,7 +290,7 @@ function DriveFilePicker({ onSelect }: { onSelect: (file: GoogleDocFile) => void
           </div>
         ) : (
           filtered.map(f => (
-            <button
+            <button type="button"
               key={f.id}
               className="drive-picker-item"
               onClick={() => onSelect(f)}

--- a/src/components/AgentHoverCard.tsx
+++ b/src/components/AgentHoverCard.tsx
@@ -32,7 +32,7 @@ export function AgentHoverCard({ name, agentState, agentConfig, onRemove }: { na
       {onRemove && (
         <>
           <div className="agent-hover-card-divider" />
-          <button className="agent-hover-card-remove" onClick={onRemove}>Remove agent</button>
+          <button type="button" className="agent-hover-card-remove" onClick={onRemove}>Remove agent</button>
         </>
       )}
     </div>

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -91,11 +91,11 @@ export const ChatMessage = memo(({ m, sameSender, agentState, userAvatarUrl, onA
         )}
         {m.proposal && m.proposal.status === 'pending' && (
           <div className="msg-proposal-actions">
-            <button
+            <button type="button"
               className="msg-proposal-btn msg-proposal-approve"
               onClick={() => onApproveProposal?.(m.id)}
             >{m.proposal.type === 'edit' ? 'Apply' : 'Approve'}</button>
-            <button
+            <button type="button"
               className="msg-proposal-btn msg-proposal-reject"
               onClick={() => onRejectProposal?.(m.id)}
             >Dismiss</button>

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -40,7 +40,7 @@ export function EditorPanel({
   return (
     <div className="doc-panel" role="main" aria-label="Document editor">
       <div className="doc-toolbar" role="toolbar" aria-label="Formatting options">
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('bold') ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleBold().run()}
           title="Bold (Ctrl+B)"
@@ -49,7 +49,7 @@ export function EditorPanel({
         >
           B
         </button>
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('italic') ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleItalic().run()}
           title="Italic (Ctrl+I)"
@@ -59,7 +59,7 @@ export function EditorPanel({
           <em>I</em>
         </button>
         <span className="doc-toolbar-sep" role="separator" />
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('heading', { level: 1 }) ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
           title="Heading 1"
@@ -68,7 +68,7 @@ export function EditorPanel({
         >
           H1
         </button>
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('heading', { level: 2 }) ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
           title="Heading 2"
@@ -77,7 +77,7 @@ export function EditorPanel({
         >
           H2
         </button>
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('heading', { level: 3 }) ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
           title="Heading 3"
@@ -87,7 +87,7 @@ export function EditorPanel({
           H3
         </button>
         <span className="doc-toolbar-sep" role="separator" />
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('bulletList') ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleBulletList().run()}
           title="Bullet List"
@@ -96,7 +96,7 @@ export function EditorPanel({
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><circle cx="3" cy="6" r="1.5" fill="currentColor" stroke="none"/><circle cx="3" cy="12" r="1.5" fill="currentColor" stroke="none"/><circle cx="3" cy="18" r="1.5" fill="currentColor" stroke="none"/></svg>
         </button>
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('orderedList') ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleOrderedList().run()}
           title="Ordered List"
@@ -106,7 +106,7 @@ export function EditorPanel({
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><line x1="10" y1="6" x2="21" y2="6"/><line x1="10" y1="12" x2="21" y2="12"/><line x1="10" y1="18" x2="21" y2="18"/><text x="1" y="8" fontSize="8" fill="currentColor" stroke="none" fontFamily="sans-serif">1</text><text x="1" y="14" fontSize="8" fill="currentColor" stroke="none" fontFamily="sans-serif">2</text><text x="1" y="20" fontSize="8" fill="currentColor" stroke="none" fontFamily="sans-serif">3</text></svg>
         </button>
         <span className="doc-toolbar-sep" role="separator" />
-        <button
+        <button type="button"
           className={`doc-toolbar-btn ${editor.isActive('codeBlock') ? 'active' : ''}`}
           onClick={() => editor.chain().focus().toggleCodeBlock().run()}
           title="Code Block"
@@ -115,7 +115,7 @@ export function EditorPanel({
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
         </button>
-        <button
+        <button type="button"
           className="doc-toolbar-btn"
           onClick={() => editor.chain().focus().setHorizontalRule().run()}
           title="Horizontal Rule"
@@ -124,7 +124,7 @@ export function EditorPanel({
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true"><line x1="3" y1="12" x2="21" y2="12"/></svg>
         </button>
         <span className="doc-toolbar-sep" role="separator" />
-        <button
+        <button type="button"
           className="doc-toolbar-btn"
           onClick={() => editor.chain().focus().undo().run()}
           disabled={!editor.can().undo()}
@@ -133,7 +133,7 @@ export function EditorPanel({
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
         </button>
-        <button
+        <button type="button"
           className="doc-toolbar-btn"
           onClick={() => editor.chain().focus().redo().run()}
           disabled={!editor.can().redo()}
@@ -149,7 +149,7 @@ export function EditorPanel({
           </>
         )}
         <span className="doc-toolbar-spacer" />
-        <button
+        <button type="button"
           className="doc-toolbar-btn"
           onClick={() => {
             const text = editor.getText()
@@ -165,7 +165,7 @@ export function EditorPanel({
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         </button>
-        <button
+        <button type="button"
           className="doc-toolbar-btn"
           onClick={async () => {
             const token = providerToken || (await supabase.auth.getSession()).data.session?.provider_token

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -44,13 +44,13 @@ export class ErrorBoundary extends Component<Props, State> {
             </span>
           </div>
           <div className="error-boundary-actions">
-            <button
+            <button type="button"
               className="error-boundary-btn"
               onClick={() => this.setState({ hasError: false, error: null })}
             >
               Try again
             </button>
-            <button
+            <button type="button"
               className="error-boundary-btn error-boundary-btn-secondary"
               onClick={() => window.location.reload()}
             >

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -103,7 +103,7 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
 
         {continueSession && (
           <div className="home-actions">
-            <button className="home-action-btn" onClick={() => onSelectSession(continueSession)}>
+            <button type="button" className="home-action-btn" onClick={() => onSelectSession(continueSession)}>
               Continue: {continueSession.title}
             </button>
           </div>
@@ -112,7 +112,7 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
         {onStarterPick ? (
           <div className="home-starters">
             {STARTERS.map(s => (
-              <button
+              <button type="button"
                 key={s.id}
                 className="home-starter-card"
                 onClick={() => onStarterPick({ id: s.id, title: s.title, template: s.template, agents: s.agents })}
@@ -129,7 +129,7 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
           </div>
         ) : (
           <div className="home-actions">
-            <button className="home-action-btn home-action-primary" onClick={onNewDoc}>
+            <button type="button" className="home-action-btn home-action-primary" onClick={onNewDoc}>
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
               New document
             </button>

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -70,7 +70,7 @@ export function SessionHeader({
               <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.5-1.5" />
             </svg>
           </button>}
-          {!isViewMode && <button
+          {!isViewMode && <button type="button"
             className={`header-pause-btn ${agentsPaused ? 'paused' : ''}`}
             onClick={onTogglePause}
             title={agentsPaused ? 'Resume agents' : 'Pause agents'}
@@ -113,7 +113,7 @@ export function SessionHeader({
               <BlobAvatar name="Tambo" size={18} color="#a78bfa" />
             </div>
             {activeAgents.length < 4 && (
-              <button
+              <button type="button"
                 className="header-add-agent"
                 onClick={onToggleConfigurator}
                 title="Add agent"

--- a/src/components/TamboChat.tsx
+++ b/src/components/TamboChat.tsx
@@ -234,7 +234,7 @@ export function TamboChat({
       <div className="chat-messages" role="log" aria-label="Chat messages" aria-live="polite">
         <div className="chat-messages-inner">
           {hiddenCount > 0 && (
-            <button className="load-older-btn" onClick={() => setChatVisibleCount(c => c + 50)}>
+            <button type="button" className="load-older-btn" onClick={() => setChatVisibleCount(c => c + 50)}>
               Load {Math.min(50, hiddenCount)} older messages
             </button>
           )}
@@ -285,7 +285,7 @@ export function TamboChat({
       {messages.length === 0 && (
         <div className="chat-suggestions">
           {['Help me outline a product spec', 'Review my draft for clarity', 'What should this doc cover?', 'Brainstorm ideas for this topic'].map(text => (
-            <button key={text} className="chat-suggestion-chip" onClick={() => onSendSuggestion(text)}>{text}</button>
+            <button type="button" key={text} className="chat-suggestion-chip" onClick={() => onSendSuggestion(text)}>{text}</button>
           ))}
         </div>
       )}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -32,8 +32,8 @@ export const TaskCard = memo(({ event, onAdd, onDismiss }: {
           <span className="task-card-agent-names">{event.task.assignedAgents.join(' + ')}</span>
         </div>
         <div className="task-card-actions">
-          <button className="task-card-btn task-card-btn-primary" onClick={() => onAdd?.(event.task)}>Add to plan</button>
-          <button className="task-card-btn task-card-btn-ghost" onClick={onDismiss}>Dismiss</button>
+          <button type="button" className="task-card-btn task-card-btn-primary" onClick={() => onAdd?.(event.task)}>Add to plan</button>
+          <button type="button" className="task-card-btn task-card-btn-ghost" onClick={onDismiss}>Dismiss</button>
         </div>
       </div>
     )
@@ -53,8 +53,8 @@ export const TaskCard = memo(({ event, onAdd, onDismiss }: {
           <span className="task-card-agent-names">{event.task.assignedAgents.join(' + ')}</span>
         </div>
         <div className="task-card-actions">
-          <button className="task-card-btn task-card-btn-primary" onClick={() => onAdd?.(event.task)}>Add task</button>
-          <button className="task-card-btn task-card-btn-ghost" onClick={onDismiss}>Ignore</button>
+          <button type="button" className="task-card-btn task-card-btn-primary" onClick={() => onAdd?.(event.task)}>Add task</button>
+          <button type="button" className="task-card-btn task-card-btn-ghost" onClick={onDismiss}>Ignore</button>
         </div>
       </div>
     )

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -70,7 +70,7 @@ function Toast({ item, onDismiss }: ToastItemProps) {
         {item.type === 'info' && <InfoIcon />}
       </span>
       <span className="toast-message">{item.message}</span>
-      <button
+      <button type="button"
         className="toast-close"
         onClick={() => onDismiss(item.id)}
         aria-label="Dismiss notification"

--- a/src/components/WorkPlanCard.tsx
+++ b/src/components/WorkPlanCard.tsx
@@ -34,13 +34,13 @@ export const WorkPlanCard = memo(({ presetTitle, tasks: initialTasks, onStart, o
                 ))}
                 <span className="work-plan-agent-names">{t.assignedAgents.join(', ')}</span>
               </span>
-              <button className="work-plan-remove" onClick={() => removeTask(i)} title="Remove task">&times;</button>
+              <button type="button" className="work-plan-remove" onClick={() => removeTask(i)} title="Remove task">&times;</button>
             </div>
           ))}
         </div>
         <div className="work-plan-footer">
-          <button className="work-plan-btn-ghost" onClick={onCancel}>Cancel</button>
-          <button
+          <button type="button" className="work-plan-btn-ghost" onClick={onCancel}>Cancel</button>
+          <button type="button"
             className="work-plan-btn-primary"
             onClick={() => onStart(tasks)}
             disabled={tasks.length === 0}


### PR DESCRIPTION
## Summary
Native `<button>` defaults to `type="submit"` inside a `<form>`, which can cause accidental form submissions when the button has a custom `onClick`. The codebase has no `<form>` elements today so this is not a live bug — but it's a correctness footgun waiting for the first `<form>`. Adds `type="button"` explicitly everywhere.

Script-driven: regex match of `<button` tags missing any `type=` attribute, across `src/` excluding `src/components/tambo/` (vendored) and `src/components/generative/`. 62 buttons across 16 files.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
