### PR TITLE
a11y: add aria-hidden to 16 decorative SVGs

### DIFF
--- a/src/CommandPalette.tsx
+++ b/src/CommandPalette.tsx
@@ -39,7 +39,7 @@ export function CommandPalette({ commands, onClose }: Props) {
     >
       <div className="cmd-palette">
         <div className="cmd-palette-input-wrap">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="8" />
             <line x1="21" y1="21" x2="16.65" y2="16.65" />
           </svg>

--- a/src/ExperimentControls.tsx
+++ b/src/ExperimentControls.tsx
@@ -45,7 +45,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
           <h2 className="exp-title">Settings</h2>
           <div className="exp-header-actions">
             <button type="button" className="exp-reset" onClick={resetAll}>Reset all</button>
-            <button type="button" className="exp-close" onClick={onClose}>
+            <button type="button" className="exp-close" onClick={onClose} aria-label="Close settings">
               <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />

--- a/src/ExperimentControls.tsx
+++ b/src/ExperimentControls.tsx
@@ -46,7 +46,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
           <div className="exp-header-actions">
             <button type="button" className="exp-reset" onClick={resetAll}>Reset all</button>
             <button type="button" className="exp-close" onClick={onClose}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" />
                 <line x1="6" y1="6" x2="18" y2="18" />
               </svg>
@@ -76,7 +76,7 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
                     autoComplete="off"
                   />
                   <button type="button" className="exp-key-toggle" onClick={() => setKeyVisible(v => !v)} title={keyVisible ? 'Hide' : 'Show'}>
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                       {keyVisible ? (
                         <><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" /><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" /><line x1="1" y1="1" x2="23" y2="23" /></>
                       ) : (

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -122,7 +122,7 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
       <div className="sidebar-header">
         {searchOpen ? (
           <div className="sidebar-search-inline">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="11" cy="11" r="8" />
               <line x1="21" y1="21" x2="16.65" y2="16.65" />
             </svg>

--- a/src/TemplatePickerModal.tsx
+++ b/src/TemplatePickerModal.tsx
@@ -122,7 +122,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
           {showDrivePicker ? (
             <>
               <button type="button" className="template-picker-back" onClick={() => setShowDrivePicker(false)}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="15 18 9 12 15 6" />
                 </svg>
               </button>
@@ -132,7 +132,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
             <span className="template-picker-title">New document</span>
           )}
           <button type="button" className="template-picker-close" onClick={onClose}>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
@@ -153,7 +153,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
               setShowDrivePicker(true)
             }}
           >
-            <svg width="20" height="20" viewBox="0 0 87.3 78" xmlns="http://www.w3.org/2000/svg">
+            <svg aria-hidden="true" width="20" height="20" viewBox="0 0 87.3 78" xmlns="http://www.w3.org/2000/svg">
               <path d="m6.6 66.85 3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3l13.75-23.8h-27.5c0 1.55.4 3.1 1.2 4.5z" fill="#0066da"/>
               <path d="m43.65 25-13.75-23.8c-1.35.8-2.5 1.9-3.3 3.3l-20.4 35.3c-.8 1.4-1.2 2.95-1.2 4.5h27.5z" fill="#00ac47"/>
               <path d="m73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75 7.65-13.25c.8-1.4 1.2-2.95 1.2-4.5h-27.5l5.85 13.95z" fill="#ea4335"/>
@@ -165,7 +165,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
               <span className="template-picker-item-name">Import from Google Docs</span>
               <span className="template-picker-item-desc">Bring in an existing document for review</span>
             </div>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-disabled)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-disabled)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="9 18 15 12 9 6" />
             </svg>
           </button>
@@ -271,7 +271,7 @@ function DriveFilePicker({ onSelect }: { onSelect: (file: GoogleDocFile) => void
   return (
     <div className="drive-picker">
       <div className="drive-picker-search">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <circle cx="11" cy="11" r="8" />
           <line x1="21" y1="21" x2="16.65" y2="16.65" />
         </svg>
@@ -295,7 +295,7 @@ function DriveFilePicker({ onSelect }: { onSelect: (file: GoogleDocFile) => void
               className="drive-picker-item"
               onClick={() => onSelect(f)}
             >
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <svg aria-hidden="true" width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" stroke="#4285f4" strokeWidth="1.5" fill="none" />
                 <polyline points="14 2 14 8 20 8" stroke="#4285f4" strokeWidth="1.5" fill="none" />
                 <line x1="8" y1="13" x2="16" y2="13" stroke="#4285f4" strokeWidth="1.5" />

--- a/src/TemplatePickerModal.tsx
+++ b/src/TemplatePickerModal.tsx
@@ -121,7 +121,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
         <div className="template-picker-header">
           {showDrivePicker ? (
             <>
-              <button type="button" className="template-picker-back" onClick={() => setShowDrivePicker(false)}>
+              <button type="button" className="template-picker-back" onClick={() => setShowDrivePicker(false)} aria-label="Back to templates">
                 <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="15 18 9 12 15 6" />
                 </svg>
@@ -131,7 +131,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
           ) : (
             <span className="template-picker-title">New document</span>
           )}
-          <button type="button" className="template-picker-close" onClick={onClose}>
+          <button type="button" className="template-picker-close" onClick={onClose} aria-label="Close">
             <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" />
               <line x1="6" y1="6" x2="18" y2="18" />

--- a/src/components/EditorPanel.tsx
+++ b/src/components/EditorPanel.tsx
@@ -202,19 +202,19 @@ export function EditorPanel({
           disabled={driveStatus === 'saving'}
         >
           {driveStatus === 'saving' ? (
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ animation: 'spin 1s linear infinite' }}>
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ animation: 'spin 1s linear infinite' }}>
               <path d="M21 12a9 9 0 1 1-6.219-8.56" />
             </svg>
           ) : driveStatus === 'saved' ? (
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#30d158" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#30d158" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="20 6 9 17 4 12" />
             </svg>
           ) : driveStatus === 'error' ? (
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ff6961" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#ff6961" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
             </svg>
           ) : (
-            <svg width="14" height="14" viewBox="0 0 87.3 78" xmlns="http://www.w3.org/2000/svg"><path d="m6.6 66.85 3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3l13.75-23.8h-27.5c0 1.55.4 3.1 1.2 4.5z" fill="#0066da"/><path d="m43.65 25-13.75-23.8c-1.35.8-2.5 1.9-3.3 3.3l-20.4 35.3c-.8 1.4-1.2 2.95-1.2 4.5h27.5z" fill="#00ac47"/><path d="m73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75 7.65-13.25c.8-1.4 1.2-2.95 1.2-4.5h-27.5l5.85 13.95z" fill="#ea4335"/><path d="m43.65 25 13.75-23.8c-1.35-.8-2.9-1.2-4.5-1.2h-18.5c-1.6 0-3.15.45-4.5 1.2z" fill="#00832d"/><path d="m59.8 53h-32.3l-13.75 23.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z" fill="#2684fc"/><path d="m73.4 26.5-10.1-17.5c-.8-1.4-1.95-2.5-3.3-3.3l-13.75 23.8 16.15 23.8h27.45c0-1.55-.4-3.1-1.2-4.5z" fill="#ffba00"/></svg>
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 87.3 78" xmlns="http://www.w3.org/2000/svg"><path d="m6.6 66.85 3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3l13.75-23.8h-27.5c0 1.55.4 3.1 1.2 4.5z" fill="#0066da"/><path d="m43.65 25-13.75-23.8c-1.35.8-2.5 1.9-3.3 3.3l-20.4 35.3c-.8 1.4-1.2 2.95-1.2 4.5h27.5z" fill="#00ac47"/><path d="m73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75 7.65-13.25c.8-1.4 1.2-2.95 1.2-4.5h-27.5l5.85 13.95z" fill="#ea4335"/><path d="m43.65 25 13.75-23.8c-1.35-.8-2.9-1.2-4.5-1.2h-18.5c-1.6 0-3.15.45-4.5 1.2z" fill="#00832d"/><path d="m59.8 53h-32.3l-13.75 23.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z" fill="#2684fc"/><path d="m73.4 26.5-10.1-17.5c-.8-1.4-1.95-2.5-3.3-3.3l-13.75 23.8 16.15 23.8h27.45c0-1.55-.4-3.1-1.2-4.5z" fill="#ffba00"/></svg>
           )}
         </button>
       </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -31,7 +31,7 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div className="error-boundary">
           <div className="error-boundary-icon">
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="10" />
               <line x1="12" y1="8" x2="12" y2="12" />
               <line x1="12" y1="16" x2="12.01" y2="16" />

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -130,7 +130,7 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
         ) : (
           <div className="home-actions">
             <button type="button" className="home-action-btn home-action-primary" onClick={onNewDoc}>
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
               New document
             </button>
           </div>


### PR DESCRIPTION
## Summary
These are all icon-inside-labeled-button SVGs (or purely decorative glyphs). Without `aria-hidden`, screen readers may read something like "button Save, graphic" or duplicate the label text. Script-driven across `src/` excluding `tambo/` and `generative/`.

- Skipping `MarkupLogo.tsx` — that's a standalone logo and needs `role="img"` + `aria-label`, not `aria-hidden` (separate PR).
- Skipping `ShapeAvatar.tsx` — same reason.
- 16 SVGs across 7 files.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (161 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/211" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
