### PR TITLE
feat: agent teams — named groups with shared mission context

### DIFF
--- a/docs/brainstorms/2026-04-19-agent-teams.md
+++ b/docs/brainstorms/2026-04-19-agent-teams.md
@@ -1,0 +1,108 @@
+# Agent Teams — Making Four Individuals Feel Like a Crew
+
+**Date:** 2026-04-19
+**Status:** brainstorm
+**Code seed:** [`src/lib/agent-teams.ts`](../../src/lib/agent-teams.ts)
+
+## The observation
+
+Today Markup has four agents — Aiden, Nova, Lex, Mira — and each runs
+independently. The existing `HomeDashboard` "Full Team" starter bundles
+all four into a doc, but they still behave as four parallel individuals.
+There is no shared context, no role hierarchy, no notion of *"we are
+reviewing this together."*
+
+This matters because users start asking the same question once they've
+lived with the product for a week: **"Which of you should I ask?"** And
+the only answer the current design can give is "whichever one you
+@-mention" — which pushes coordination onto the human.
+
+## The shift
+
+A **team** is a named group of agents with a **shared mission context**
+prepended to each member's persona. The mission context is what makes
+three agents feel like *a team* rather than three overlapping solo acts.
+
+Concretely (this PR ships the seed):
+
+```
+teamContext: "You are part of the Launch Review team. Your collective
+goal is to make the document ship-ready in the next 72 hours.
+Prioritize concrete gaps over theoretical concerns. Defer to your
+teammates on their domains..."
+```
+
+The team context is static, not dynamic — it's a declarative prompt
+modification, not an orchestrator behavior change. That keeps it cheap
+to iterate: new teams are data, not code.
+
+## Shipped in this PR
+
+`TEAM_PRESETS` with five starter teams:
+
+1. **Launch Review** (Aiden + Nova + Mira) — ship-readiness sweep
+2. **Compliance Review** (Lex + Aiden) — legal gate for external share
+3. **Design Crit** (Mira + Nova) — user-first challenge
+4. **Architecture Review** (Aiden + Lex) — systems and constraints
+5. **Full Review** (all four) — the board meeting
+
+Plus a pure `resolveTeam(teamId)` function that expands a team into
+concrete `AgentConfig[]` with persona = `${teamContext}\n\n${persona}`.
+
+## Not shipped (follow-ups)
+
+**UI wiring.** The module is unused until a follow-up PR adds a "Start a
+team" affordance to `HomeDashboard` or a "Load a team" chip in
+`AgentConfigurator`. Shipping the module first lets the UI surface the
+same data structure from multiple entry points (home, command palette,
+existing-session flow).
+
+**Dynamic team context.** Right now `teamContext` is a static string.
+The interesting future shape is *team context as a live document that
+the team negotiates* — e.g., the team collectively adjusts "our
+priority this session is speed over completeness" at the top of a
+chat, and that updates every member's effective prompt. This is where
+the "team volume dial" from `2026-04-19-multi-entity-collab-design-lenses.md`
+lands as a concrete feature.
+
+**Team-level roles.** Leads, seconds, silent observers. The `Lex leads;
+Aiden supports` framing in today's Compliance Review teamContext is the
+proto-role hierarchy. A proper implementation would be a field per
+member: `role: 'lead' | 'second' | 'observer'`, with orchestrator
+behaviors to match (observer agents don't take turns unless summoned).
+
+**Per-doc team memory.** A team should remember what it decided last
+time it reviewed *this kind of doc*. Separate from user preferences;
+scoped to the team. Interesting because teams could build reputations
+and patterns over time — "the Launch Review team has a thing about
+testing edge cases in the second round."
+
+## Where teams meet multi-human
+
+In the multi-entity brainstorm we talked about **leasehold authority** —
+agents propose, humans adopt. Teams are the natural aggregation layer:
+a human says "I want the Launch Review team's take" and gets one
+coherent output with three voices and clear domain ownership, not three
+disjoint comment threads.
+
+And when multiple humans are in a doc, a team is a *shared handle* —
+"Priya pinged the Compliance Review team" reads as a team action, not
+four separate agent pings. That's the UX win that makes multi-human +
+multi-agent legible rather than chaotic.
+
+## Open questions
+
+- Should teams be discoverable/shareable across users, or per-workspace?
+  Probably per-workspace with a "Copy to my library" affordance.
+- When a team is active, is every member in-doc by default, or can a
+  subset of the team be "on call"? Inclined toward the latter — a
+  four-person team with two observers behaves very differently from
+  four equally-loud agents.
+- How does adding a custom agent interact with the preset teams? When
+  I drag @Ivy (a custom agent) into a Launch Review, does she inherit
+  the team context? Inclined toward yes, with an opt-out flag on the
+  agent.
+- Do teams get their own avatar/identity in the UI, or are they just
+  labels? A named-team chip (like `🚀 Launch Review`) in the header
+  that replaces the stack of individual agent avatars when a team is
+  active feels right.

--- a/src/__tests__/agent-teams.test.ts
+++ b/src/__tests__/agent-teams.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { TEAM_PRESETS, resolveTeam, getTeam } from '../lib/agent-teams'
+import { AGENT_PRESETS } from '../lib/agent-presets'
+
+describe('agent-teams', () => {
+  it('all team members resolve to a known preset', () => {
+    const presetNames = new Set(AGENT_PRESETS.map(p => p.name))
+    for (const team of TEAM_PRESETS) {
+      for (const member of team.memberPresetNames) {
+        expect(presetNames.has(member)).toBe(true)
+      }
+    }
+  })
+
+  it('resolveTeam returns agents with team context prepended', () => {
+    const agents = resolveTeam('launch-review')
+    expect(agents).not.toBeNull()
+    expect(agents!.length).toBe(3)
+    const team = getTeam('launch-review')!
+    for (const agent of agents!) {
+      expect(agent.persona.startsWith(team.teamContext)).toBe(true)
+    }
+  })
+
+  it('resolveTeam returns null for unknown id', () => {
+    expect(resolveTeam('nonexistent')).toBeNull()
+  })
+
+  it('teams are distinct', () => {
+    const ids = TEAM_PRESETS.map(t => t.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('getTeam returns the matching team', () => {
+    const team = getTeam('full-review')
+    expect(team?.memberPresetNames.length).toBe(4)
+  })
+})

--- a/src/lib/agent-teams.ts
+++ b/src/lib/agent-teams.ts
@@ -1,0 +1,104 @@
+import type { AgentConfig } from '../types'
+import { AGENT_PRESETS } from './agent-presets'
+
+/**
+ * An \`AgentTeam\` is a named, reusable group of agents with a shared
+ * team-level context. Unlike the \`HomeDashboard\` starters (which pair a
+ * team with a specific doc template), teams are template-agnostic: you
+ * can run the "Launch Review" team against a PRD, a tech spec, or a
+ * blank canvas.
+ *
+ * The \`teamContext\` string is prepended to each agent's persona when
+ * the team is active, so agents know they're collaborating under a
+ * shared mission rather than four parallel individuals. This is the
+ * seam where the multi-entity brainstorm's "shared stance" ideas
+ * eventually land.
+ *
+ * Team membership is expressed by preset name rather than full
+ * \`AgentConfig\` to keep the module declarative — the resolver fills in
+ * persona/color from \`AGENT_PRESETS\` at runtime so a future edit to an
+ * agent persona flows through every team automatically.
+ */
+export interface AgentTeam {
+  id: string
+  name: string
+  description: string
+  emoji: string
+  memberPresetNames: string[]
+  teamContext: string
+}
+
+export const TEAM_PRESETS: AgentTeam[] = [
+  {
+    id: 'launch-review',
+    name: 'Launch Review',
+    description: 'Ship-readiness sweep: scope, risk, UX polish.',
+    emoji: '🚀',
+    memberPresetNames: ['Aiden', 'Nova', 'Mira'],
+    teamContext:
+      'You are part of the Launch Review team. Your collective goal is to make the document ship-ready in the next 72 hours. Prioritize concrete gaps and unknowns over theoretical concerns. Defer to your teammates on their domains: architecture (Aiden), user and go-to-market (Nova), visual and UX (Mira).',
+  },
+  {
+    id: 'compliance-review',
+    name: 'Compliance Review',
+    description: 'Legal, privacy, and regulatory sweep before external share.',
+    emoji: '⚖️',
+    memberPresetNames: ['Lex', 'Aiden'],
+    teamContext:
+      'You are part of the Compliance Review team. Your collective goal is to find legal, privacy, and regulatory risks before this document is shared externally. Lex leads; Aiden supports by flagging technical decisions that create compliance obligations (data retention, PII handling, audit surfaces).',
+  },
+  {
+    id: 'design-crit',
+    name: 'Design Crit',
+    description: 'Product and design critique from user-first perspectives.',
+    emoji: '🎨',
+    memberPresetNames: ['Mira', 'Nova'],
+    teamContext:
+      'You are part of the Design Crit team. Your collective goal is to challenge this document from the user\'s perspective. Mira focuses on interaction and visual hierarchy; Nova focuses on behavioral psychology and adoption. Disagree with each other when your lenses genuinely conflict — don\'t harmonize for the sake of harmony.',
+  },
+  {
+    id: 'architecture-review',
+    name: 'Architecture Review',
+    description: 'Systems, APIs, failure modes, and scalability.',
+    emoji: '🏗️',
+    memberPresetNames: ['Aiden', 'Lex'],
+    teamContext:
+      'You are part of the Architecture Review team. Your collective goal is to stress-test the technical design. Aiden owns system boundaries, data flow, and failure modes. Lex owns regulatory and contractual constraints that shape the architecture (residency, retention, auditability).',
+  },
+  {
+    id: 'full-review',
+    name: 'Full Review',
+    description: 'All four perspectives — the board meeting.',
+    emoji: '🗂️',
+    memberPresetNames: ['Aiden', 'Nova', 'Lex', 'Mira'],
+    teamContext:
+      'You are part of the Full Review team — all four disciplines at the table. Your collective goal is a complete, cross-functional review. Stay in your lane: Aiden for architecture, Nova for product, Lex for legal, Mira for design. When two of you overlap, defer to the owner of that domain.',
+  },
+]
+
+/**
+ * Resolve a team preset into concrete \`AgentConfig[]\` with team context
+ * prepended to each persona. The resolver is pure: pass the same team
+ * id, get the same agents back.
+ */
+export function resolveTeam(teamId: string): AgentConfig[] | null {
+  const team = TEAM_PRESETS.find(t => t.id === teamId)
+  if (!team) return null
+  return team.memberPresetNames
+    .map(name => {
+      const preset = AGENT_PRESETS.find(p => p.name === name)
+      if (!preset) return null
+      return {
+        name: preset.name,
+        persona: `${team.teamContext}\n\n${preset.persona}`,
+        owner: preset.owner,
+        color: preset.color,
+      }
+    })
+    .filter((a): a is AgentConfig => a !== null)
+}
+
+/** Look up a team by id. */
+export function getTeam(teamId: string): AgentTeam | undefined {
+  return TEAM_PRESETS.find(t => t.id === teamId)
+}


### PR DESCRIPTION
## Summary

Seeds the "agent teams" concept: named groups of existing agent presets with a `teamContext` prompt prepended to each member's persona. Makes the crew feel like a team reviewing together rather than four parallel individuals.

### Shipped

`src/lib/agent-teams.ts` exports:
- `AgentTeam` interface
- `TEAM_PRESETS` — five starter teams:
  - 🚀 **Launch Review** (Aiden + Nova + Mira) — ship-readiness sweep
  - ⚖️ **Compliance Review** (Lex + Aiden) — legal gate for external share
  - 🎨 **Design Crit** (Mira + Nova) — user-first challenge
  - 🏗️ **Architecture Review** (Aiden + Lex) — systems + constraints
  - 🗂️ **Full Review** (all four) — the board meeting
- `resolveTeam(id)` — expands a team into `AgentConfig[]` with `teamContext` prepended to each persona
- `getTeam(id)` — lookup by id

Plus 5 tests: membership validity, context prepending, null for unknown ids, id uniqueness, member count.

### Not shipped (follow-ups)

- UI wiring. Module is unused until a follow-up adds "Start a team" to `HomeDashboard` or a "Load a team" chip in `AgentConfigurator`. Shipping the seed separately so multiple entry points can consume the same data structure.
- Dynamic team context, team roles (lead/second/observer), per-doc team memory — all flagged in the brainstorm as next steps.

Brainstorm: [`docs/brainstorms/2026-04-19-agent-teams.md`](../blob/claude/agent-teams-concept/docs/brainstorms/2026-04-19-agent-teams.md)

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests, +5 new)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
