### PR TITLE
perf: memoize ProgressBar and ReasoningChain

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,8 +1,10 @@
+import { memo } from 'react'
+
 interface Props {
   active: boolean
 }
 
-export function ProgressBar({ active }: Props) {
+export const ProgressBar = memo(function ProgressBar({ active }: Props) {
   if (!active) return null
 
   return (
@@ -10,4 +12,4 @@ export function ProgressBar({ active }: Props) {
       <div className="progress-bar-fill" />
     </div>
   )
-}
+})

--- a/src/components/ReasoningChain.tsx
+++ b/src/components/ReasoningChain.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { memo, useState } from 'react'
 
-export function ReasoningChain({ steps }: { steps: string[] }) {
+export const ReasoningChain = memo(function ReasoningChain({ steps }: { steps: string[] }) {
   const [expanded, setExpanded] = useState(false)
   return (
     <div className={`reasoning-chain ${expanded ? 'expanded' : ''}`}>
@@ -28,4 +28,4 @@ export function ReasoningChain({ steps }: { steps: string[] }) {
       )}
     </div>
   )
-}
+})


### PR DESCRIPTION
## Summary
Both `ProgressBar` and `ReasoningChain` are pure presentational leaves with cheap render logic but re-render on every parent tick. Wrapping with `React.memo` skips those unnecessary renders. Zero behavior change.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
