### PR TITLE
refactor: extract App.tsx debounce magic numbers to constants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,15 @@ import { useSession, now, uid } from './hooks/useSession'
 
 const EMPTY_DOC = '<h1>Untitled</h1><p></p>'
 
+/** How long "Saved" stays visible in the header before fading. */
+const SAVED_STATUS_FADE_MS = 2000
+
+/** Debounce before the doc is persisted to Supabase after a keystroke. */
+const DOC_SAVE_DEBOUNCE_MS = 2000
+
+/** Idle time before typed doc content is surfaced to the orchestrator. */
+const DOC_EDIT_REACT_DEBOUNCE_MS = 3000
+
 function App() {
   const { user, loading: authLoading, signOut, providerToken, signInWithGoogle } = useAuth()
   const { toast } = useToast()
@@ -114,7 +123,7 @@ function App() {
         const session = activeSessionRef.current
         if (session) {
           saveDocument(session.id, ed.getHTML())
-            .then(() => { setSaveStatus('saved'); setTimeout(() => setSaveStatus('idle'), 2000) })
+            .then(() => { setSaveStatus('saved'); setTimeout(() => setSaveStatus('idle'), SAVED_STATUS_FADE_MS) })
             .catch(err => { console.error('[App] saveDocument error:', err); setSaveStatus('idle'); toast({ type: 'error', message: 'Failed to save document' }) })
           // Sync title from first H1
           const json = ed.getJSON() as JSONContent
@@ -127,7 +136,7 @@ function App() {
             )
           }
         }
-      }, 2000)
+      }, DOC_SAVE_DEBOUNCE_MS)
       // Detect user typing in doc
       if (docEditTimer.current) clearTimeout(docEditTimer.current)
       docEditTimer.current = window.setTimeout(() => {
@@ -143,7 +152,7 @@ function App() {
             instruction: `The user just typed this in the document: "${added.trim().slice(0, 200)}". React to it — if it's an instruction, follow it. If it's content, build on it.`,
           })
         }
-      }, 3000)
+      }, DOC_EDIT_REACT_DEBOUNCE_MS)
     },
   })
   useEffect(() => { editorRef.current = editor })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ function App() {
   const editorRef = useRef<import('@tiptap/react').Editor | null>(null)
   const docSaveTimer = useRef<number | null>(null)
   const docEditTimer = useRef<number | null>(null)
+  const savedStatusTimer = useRef<number | null>(null)
   const lastDocSnapshot = useRef('')
 
   const editor = useEditor({
@@ -123,7 +124,11 @@ function App() {
         const session = activeSessionRef.current
         if (session) {
           saveDocument(session.id, ed.getHTML())
-            .then(() => { setSaveStatus('saved'); setTimeout(() => setSaveStatus('idle'), SAVED_STATUS_FADE_MS) })
+            .then(() => {
+              setSaveStatus('saved')
+              if (savedStatusTimer.current) clearTimeout(savedStatusTimer.current)
+              savedStatusTimer.current = window.setTimeout(() => setSaveStatus('idle'), SAVED_STATUS_FADE_MS)
+            })
             .catch(err => { console.error('[App] saveDocument error:', err); setSaveStatus('idle'); toast({ type: 'error', message: 'Failed to save document' }) })
           // Sync title from first H1
           const json = ed.getJSON() as JSONContent


### PR DESCRIPTION
## Summary
`setTimeout(..., 2000)` and `setTimeout(..., 3000)` appeared inline in `App.tsx` for three different behaviors. Extracts to module-scope constants:
- `SAVED_STATUS_FADE_MS` (2000) — "Saved" pill timeout
- `DOC_SAVE_DEBOUNCE_MS` (2000) — Supabase save debounce
- `DOC_EDIT_REACT_DEBOUNCE_MS` (3000) — orchestrator react debounce

Makes future tuning a one-line change per behavior and removes the coincidence where save-fade and save-debounce happened to share a value.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
