### PR TITLE
chore: gate debug console.log behind DEV

### DIFF
--- a/src/agent-actions.ts
+++ b/src/agent-actions.ts
@@ -477,7 +477,7 @@ export function executeAgentAction(
     const streamBlocks = contentToStreamBlocks(action.content || '').filter(block => {
       if (block.type === 'heading') {
         if (existingHeadings.has(block.text.trim().toLowerCase())) {
-          console.log('[agent-actions] skipping duplicate heading:', block.text)
+          if (import.meta.env.DEV) console.log('[agent-actions] skipping duplicate heading:', block.text)
           return false
         }
       }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -40,7 +40,7 @@ const rateLimiter = {
     // If we're in backoff, check if it's expired
     if (Date.now() < this.backoffUntil) {
       const wait = this.backoffUntil - Date.now()
-      console.log(`[rate] backing off for ${Math.round(wait / 1000)}s`)
+      if (import.meta.env.DEV) console.log(`[rate] backing off for ${Math.round(wait / 1000)}s`)
       await new Promise<void>((resolve) => {
         const id = setTimeout(() => { this.pendingTimers.delete(id); resolve() }, wait)
         this.pendingTimers.add(id)
@@ -445,7 +445,7 @@ export async function askAgent(params: AskParams): Promise<AgentAction> {
     }
 
     // Debug: log propose_edit fields to diagnose empty content issues
-    if (action.type === 'propose_edit') {
+    if (action.type === 'propose_edit' && import.meta.env.DEV) {
       console.log('[agent]', params.agentName, 'propose_edit raw:', {
         editKind: action.editKind,
         editTarget: action.editTarget,
@@ -462,7 +462,7 @@ export async function askAgent(params: AskParams): Promise<AgentAction> {
       )
     }
 
-    console.log('[agent]', params.agentName, action.type, action.thought, action.reasoning)
+    if (import.meta.env.DEV) console.log('[agent]', params.agentName, action.type, action.thought, action.reasoning)
 
     // Post-process: trim thought and reasoning
     if (action.thought) {

--- a/src/hooks/useOrchestrator.ts
+++ b/src/hooks/useOrchestrator.ts
@@ -155,7 +155,7 @@ export function useOrchestrator({
       if (agentsChanged && prevAgents.length > 0) {
         const newAgentNames = activeAgents.filter(a => !prevAgents.some(p => p.name === a.name)).map(a => a.name)
         if (newAgentNames.length > 0) {
-          console.log('[useOrchestrator] new agents activated:', newAgentNames.join(', '))
+          if (import.meta.env.DEV) console.log('[useOrchestrator] new agents activated:', newAgentNames.join(', '))
           events.agentConfigChanged(activeAgents.length, activeAgents.map(a => a.name))
         }
       }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -60,7 +60,7 @@ interface OrchestratorHandle {
 }
 
 function log(...args: unknown[]) {
-  console.log('[orch]', ...args)
+  if (import.meta.env.DEV) console.log('[orch]', ...args)
 }
 
 /** Build instruction for an agent reacting to another agent's doc edit */


### PR DESCRIPTION
## Summary
Six scattered `console.log` calls were firing in production as noise. Each now guarded with `if (import.meta.env.DEV)`:

- `orchestrator.ts`: the module-level `log()` helper
- `agent.ts`: rate-limiter backoff, propose_edit raw dump, action trace
- `agent-actions.ts`: skipping-duplicate-heading debug
- `useOrchestrator.ts`: new-agents-activated debug

Keeps `console.error` and `console.warn` as-is — those surface real problems and belong in prod.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
