### PR TITLE
a11y: add role=dialog / aria-modal to three modals

### DIFF
--- a/src/CommandPalette.tsx
+++ b/src/CommandPalette.tsx
@@ -37,7 +37,7 @@ export function CommandPalette({ commands, onClose }: Props) {
       ref={overlayRef}
       onClick={e => { if (e.target === overlayRef.current) onClose() }}
     >
-      <div className="cmd-palette">
+      <div className="cmd-palette" role="dialog" aria-modal="true" aria-label="Command palette">
         <div className="cmd-palette-input-wrap">
           <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="8" />

--- a/src/ExperimentControls.tsx
+++ b/src/ExperimentControls.tsx
@@ -40,9 +40,9 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
 
   return (
     <div className="exp-overlay" onClick={onClose}>
-      <div className="exp-panel" onClick={e => e.stopPropagation()}>
+      <div className="exp-panel" role="dialog" aria-modal="true" aria-labelledby="exp-title" onClick={e => e.stopPropagation()}>
         <div className="exp-header">
-          <h2 className="exp-title">Settings</h2>
+          <h2 className="exp-title" id="exp-title">Settings</h2>
           <div className="exp-header-actions">
             <button type="button" className="exp-reset" onClick={resetAll}>Reset all</button>
             <button type="button" className="exp-close" onClick={onClose} aria-label="Close settings">

--- a/src/TemplatePickerModal.tsx
+++ b/src/TemplatePickerModal.tsx
@@ -117,7 +117,7 @@ export function TemplatePickerModal({ onSelect, onImport, onClose, importAvailab
       ref={overlayRef}
       onClick={e => { if (e.target === overlayRef.current) { if (showDrivePicker) setShowDrivePicker(false); else onClose() } }}
     >
-      <div className="template-picker">
+      <div className="template-picker" role="dialog" aria-modal="true" aria-label={showDrivePicker ? 'Import from Google Docs' : 'New document'}>
         <div className="template-picker-header">
           {showDrivePicker ? (
             <>


### PR DESCRIPTION
## Summary
`CommandPalette`, `ExperimentControls` (Settings), and `TemplatePickerModal` all render as visual modals but have no semantic modal markup. Screen readers treated them as generic containers, and the background content wasn't suppressed from accessibility tree traversal.

Adds `role="dialog"` + `aria-modal="true"` to each modal panel, plus an accessible name (`aria-label` or `aria-labelledby` to the existing heading).

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
