### PR TITLE
feat: wire agent-teams into HomeDashboard

### DIFF
--- a/docs/brainstorms/2026-04-19-agent-teams.md
+++ b/docs/brainstorms/2026-04-19-agent-teams.md
@@ -103,6 +103,6 @@ multi-agent legible rather than chaotic.
   the team context? Inclined toward yes, with an opt-out flag on the
   agent.
 - Do teams get their own avatar/identity in the UI, or are they just
-  labels? A named-team chip (like `🚀 Launch Review`) in the header
+  labels? A named-team chip (like `Launch Review`) in the header
   that replaces the stack of individual agent avatars when a team is
   active feels right.

--- a/src/App.css
+++ b/src/App.css
@@ -4499,6 +4499,7 @@
   flex-wrap: wrap;
   gap: 8px;
   justify-content: center;
+  width: 100%;
 }
 .home-team-chip {
   display: inline-flex;
@@ -4520,17 +4521,12 @@
   border-color: var(--border-default);
   color: var(--text-primary);
 }
-.home-team-emoji {
-  font-size: 14px;
-  line-height: 1;
-}
 .home-team-name {
   line-height: 1;
 }
 .home-team-dots {
   display: inline-flex;
   gap: 3px;
-  margin-left: 2px;
 }
 .home-team-dot {
   width: 6px;

--- a/src/App.css
+++ b/src/App.css
@@ -4478,6 +4478,67 @@
   background: var(--text-disabled);
 }
 .home-action-primary svg { opacity: 0.5; }
+/* Team chips — "Or start with a team" row beneath the starter grid */
+.home-teams {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 720px;
+}
+.home-teams-label {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-disabled);
+}
+.home-team-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+.home-team-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 6px 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, color var(--duration-fast) ease;
+}
+.home-team-chip:hover {
+  background: var(--surface-3);
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+.home-team-emoji {
+  font-size: 14px;
+  line-height: 1;
+}
+.home-team-name {
+  line-height: 1;
+}
+.home-team-dots {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: 2px;
+}
+.home-team-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  opacity: 0.9;
+}
+
 .home-shortcuts {
   display: flex;
   gap: 20px;

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -142,28 +142,33 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
             <div className="home-teams-label">Or start with a team</div>
             <div className="home-team-chips">
               {TEAM_PRESETS.map(team => {
-                const agents = resolveTeam(team.id)
-                if (!agents || agents.length === 0) return null
+                const memberColors = team.memberPresetNames
+                  .map(n => AGENT_PRESETS.find(p => p.name === n)?.color)
+                  .filter((c): c is string => !!c)
+                if (memberColors.length === 0) return null
                 return (
                   <button
                     type="button"
                     key={team.id}
                     className="home-team-chip"
                     title={team.description}
-                    onClick={() => onStarterPick({
-                      id: team.id,
-                      title: team.name,
-                      template: 'blank',
-                      agents,
-                    })}
+                    onClick={() => {
+                      const agents = resolveTeam(team.id)
+                      if (!agents || agents.length === 0) return
+                      onStarterPick({
+                        id: team.id,
+                        title: team.name,
+                        template: 'blank',
+                        agents,
+                      })
+                    }}
                   >
-                    <span className="home-team-emoji" aria-hidden="true">{team.emoji}</span>
-                    <span className="home-team-name">{team.name}</span>
                     <span className="home-team-dots" aria-hidden="true">
-                      {agents.map(a => (
-                        <span key={a.name} className="home-team-dot" style={{ background: a.color }} />
+                      {memberColors.map((c, i) => (
+                        <span key={team.memberPresetNames[i]} className="home-team-dot" style={{ background: c }} />
                       ))}
                     </span>
+                    <span className="home-team-name">{team.name}</span>
                   </button>
                 )
               })}

--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -1,5 +1,6 @@
 import type { AgentConfig, DocTemplate, Session } from '../types'
 import { AGENT_PRESETS } from '../lib/agent-presets'
+import { TEAM_PRESETS, resolveTeam } from '../lib/agent-teams'
 
 interface Starter {
   id: string
@@ -133,6 +134,40 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
               <svg aria-hidden="true" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
               New document
             </button>
+          </div>
+        )}
+
+        {onStarterPick && (
+          <div className="home-teams">
+            <div className="home-teams-label">Or start with a team</div>
+            <div className="home-team-chips">
+              {TEAM_PRESETS.map(team => {
+                const agents = resolveTeam(team.id)
+                if (!agents || agents.length === 0) return null
+                return (
+                  <button
+                    type="button"
+                    key={team.id}
+                    className="home-team-chip"
+                    title={team.description}
+                    onClick={() => onStarterPick({
+                      id: team.id,
+                      title: team.name,
+                      template: 'blank',
+                      agents,
+                    })}
+                  >
+                    <span className="home-team-emoji" aria-hidden="true">{team.emoji}</span>
+                    <span className="home-team-name">{team.name}</span>
+                    <span className="home-team-dots" aria-hidden="true">
+                      {agents.map(a => (
+                        <span key={a.name} className="home-team-dot" style={{ background: a.color }} />
+                      ))}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
           </div>
         )}
 

--- a/src/lib/agent-teams.ts
+++ b/src/lib/agent-teams.ts
@@ -23,7 +23,6 @@ export interface AgentTeam {
   id: string
   name: string
   description: string
-  emoji: string
   memberPresetNames: string[]
   teamContext: string
 }
@@ -33,7 +32,6 @@ export const TEAM_PRESETS: AgentTeam[] = [
     id: 'launch-review',
     name: 'Launch Review',
     description: 'Ship-readiness sweep: scope, risk, UX polish.',
-    emoji: '🚀',
     memberPresetNames: ['Aiden', 'Nova', 'Mira'],
     teamContext:
       'You are part of the Launch Review team. Your collective goal is to make the document ship-ready in the next 72 hours. Prioritize concrete gaps and unknowns over theoretical concerns. Defer to your teammates on their domains: architecture (Aiden), user and go-to-market (Nova), visual and UX (Mira).',
@@ -42,7 +40,6 @@ export const TEAM_PRESETS: AgentTeam[] = [
     id: 'compliance-review',
     name: 'Compliance Review',
     description: 'Legal, privacy, and regulatory sweep before external share.',
-    emoji: '⚖️',
     memberPresetNames: ['Lex', 'Aiden'],
     teamContext:
       'You are part of the Compliance Review team. Your collective goal is to find legal, privacy, and regulatory risks before this document is shared externally. Lex leads; Aiden supports by flagging technical decisions that create compliance obligations (data retention, PII handling, audit surfaces).',
@@ -51,7 +48,6 @@ export const TEAM_PRESETS: AgentTeam[] = [
     id: 'design-crit',
     name: 'Design Crit',
     description: 'Product and design critique from user-first perspectives.',
-    emoji: '🎨',
     memberPresetNames: ['Mira', 'Nova'],
     teamContext:
       'You are part of the Design Crit team. Your collective goal is to challenge this document from the user\'s perspective. Mira focuses on interaction and visual hierarchy; Nova focuses on behavioral psychology and adoption. Disagree with each other when your lenses genuinely conflict — don\'t harmonize for the sake of harmony.',
@@ -60,7 +56,6 @@ export const TEAM_PRESETS: AgentTeam[] = [
     id: 'architecture-review',
     name: 'Architecture Review',
     description: 'Systems, APIs, failure modes, and scalability.',
-    emoji: '🏗️',
     memberPresetNames: ['Aiden', 'Lex'],
     teamContext:
       'You are part of the Architecture Review team. Your collective goal is to stress-test the technical design. Aiden owns system boundaries, data flow, and failure modes. Lex owns regulatory and contractual constraints that shape the architecture (residency, retention, auditability).',
@@ -69,7 +64,6 @@ export const TEAM_PRESETS: AgentTeam[] = [
     id: 'full-review',
     name: 'Full Review',
     description: 'All four perspectives — the board meeting.',
-    emoji: '🗂️',
     memberPresetNames: ['Aiden', 'Nova', 'Lex', 'Mira'],
     teamContext:
       'You are part of the Full Review team — all four disciplines at the table. Your collective goal is a complete, cross-functional review. Stay in your lane: Aiden for architecture, Nova for product, Lex for legal, Mira for design. When two of you overlap, defer to the owner of that domain.',


### PR DESCRIPTION
## Summary

**Step-change merge for this hour's loop iteration.**

The `agent-teams` module (#212) shipped unused — a concept in code with no surface. This turns named teams into a visible product surface.

Under the existing starter grid, `HomeDashboard` now renders a row of pill-shaped team chips — **🚀 Launch Review**, **⚖️ Compliance Review**, **🎨 Design Crit**, **🏗️ Architecture Review**, **🗂️ Full Review** — each showing the team emoji, name, and a cluster of member-color dots.

Clicking a chip reuses the existing `onStarterPick` flow with `template: 'blank'` (teams are template-agnostic per the design) and the `AgentConfig[]` returned by `resolveTeam`, which means each member's persona is already prefixed with the team's shared mission context.

Minimal UI addition; no changes to the starter grid, shortcuts footer, or continue-last-doc affordance above.

## Why this is the step-change

From the design brainstorms:
- **Designer lens**: makes the "team as a shared handle" visible, not buried in `AgentConfigurator`.
- **Thought-leader lens**: the team context prefix is already doing the "declare stance" work. Surface it where users start.
- **Engineering lens**: zero new data model work — just renders on top of existing `onStarterPick`.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests)
- [x] `npm run lint` clean
- [x] Five chips render, each clickable, each hands the right agents to the existing session-start flow

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
