### PR TITLE
ci: add GitHub Actions workflow (W0-T001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: lint + typecheck + test + build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read Node version
+        id: node
+        run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node.outputs.version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## What
Adds `.github/workflows/ci.yml` running lint + typecheck + test + build on PRs and pushes to main.

## Why
Every subsequent orchestration merge depends on a reliable green/red signal. First PR in Wave 0, pre-blocks all others.

Task `W0-T001` per `orchestration/plan.md`. Decision D-003 in `orchestration/decisions.md`.

## Acceptance
- [x] Workflow triggers on PR + push to main
- [x] Runs lint, typecheck, test, build in one job (fail-fast)
- [x] Uses Node version from .nvmrc
- [x] Concurrency cancels superseded runs
- [x] Caches npm installs

## Verification
Locally: lint ✓, typecheck ✓, test ✓ (166 passed in 10 files), build ✓ (7.6s).

## Risk
low — adds only a workflow file; no runtime code changed.

## Task
`W0-T001` — author: Anvil (Foundry team)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
