### PR TITLE
fix: keep team-member name aligned with color after preset miss

### DIFF
--- a/src/components/HomeDashboard.tsx
+++ b/src/components/HomeDashboard.tsx
@@ -142,10 +142,13 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
             <div className="home-teams-label">Or start with a team</div>
             <div className="home-team-chips">
               {TEAM_PRESETS.map(team => {
-                const memberColors = team.memberPresetNames
-                  .map(n => AGENT_PRESETS.find(p => p.name === n)?.color)
-                  .filter((c): c is string => !!c)
-                if (memberColors.length === 0) return null
+                const members = team.memberPresetNames
+                  .map(name => {
+                    const color = AGENT_PRESETS.find(p => p.name === name)?.color
+                    return color ? { name, color } : null
+                  })
+                  .filter((m): m is { name: string; color: string } => m !== null)
+                if (members.length === 0) return null
                 return (
                   <button
                     type="button"
@@ -164,8 +167,8 @@ export function HomeDashboard({ sessions, sessionsLoaded, onNewDoc, onSelectSess
                     }}
                   >
                     <span className="home-team-dots" aria-hidden="true">
-                      {memberColors.map((c, i) => (
-                        <span key={team.memberPresetNames[i]} className="home-team-dot" style={{ background: c }} />
+                      {members.map(m => (
+                        <span key={m.name} className="home-team-dot" style={{ background: m.color }} />
                       ))}
                     </span>
                     <span className="home-team-name">{team.name}</span>


### PR DESCRIPTION
## Summary

Follow-up to #217. Per Devin: the `filter(...)`-after-`map(...)` pattern produced a `memberColors` array whose indices no longer matched `team.memberPresetNames` if any member name failed to resolve to a preset. The React `key` was derived from the mismatched index, which would silently associate the wrong name with the wrong dot.

Switched to a single pass that either emits `{ name, color }` or returns `null`, so the surviving pairs are always correct.

No visible behavior change today (all hardcoded team member names resolve) — shipping ahead of any custom-team work that would expose this.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (166 tests)
- [x] `npm run lint` clean

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
