### PR TITLE
docs: add wave PRD stubs for chatprd population (W0-T015)

### DIFF
--- a/orchestration/wave-1-prd.md
+++ b/orchestration/wave-1-prd.md
@@ -1,0 +1,77 @@
+# Wave 1 PRD — Product depth (Quadrant A)
+
+> This is a stub. Full PRD to be generated via ChatPRD MCP at wave-entry time and pasted here.
+
+## Wave goal
+
+markup is usable for real work. Projects, sharing, export, history, organization.
+
+## Tasks in scope
+
+### Track A1: Project model (~8 PRs)
+
+- **W1-T001** Migration: `projects` table + `sessions.project_id` FK + backfill
+- **W1-T002** Supabase RLS policies for `projects`
+- **W1-T003** Session-store: `loadProjects`, `createProject`, `renameProject`, `archiveProject`
+- **W1-T004** HomeDashboard: project-scoped view + project switcher
+- **W1-T005** Sidebar: project tree (collapse/expand, drag to reorder)
+- **W1-T006** Move session between projects
+- **W1-T007** Archive / restore session
+- **W1-T008** Project-level agent persona defaults (inherit into sessions)
+
+### Track A2: Sharing + permissions (~7 PRs)
+
+- **W1-T009** Migration: `session_shares` table (role: viewer/commenter/editor) + RLS
+- **W1-T010** Share-link generation: signed-URL style tokens, expire-after toggle
+- **W1-T011** Share modal UI (invite by email, copy link, manage shares)
+- **W1-T012** Commenter role: read doc + chat, comment-only insertions
+- **W1-T013** Editor role: same as owner, minus delete-session
+- **W1-T014** Revoke access
+- **W1-T015** Shared-with-me view on HomeDashboard
+
+### Track A3: Real-time multiplayer human ↔ human (~5 PRs)
+
+- **W1-T016** Extend existing Realtime-documents (#209) to broadcast human edits too (not just agent)
+- **W1-T017** Human presence in doc: colored cursor, name chip, reuse agent-cursor decoration layer
+- **W1-T018** Conflict resolution: last-write-wins per node, warn on simultaneous edit within 2s
+- **W1-T019** Out-of-sync indicator + force-reconnect
+- **W1-T020** Multi-human + multi-agent visible in same doc
+
+### Track A4: Export (~5 PRs)
+
+- **W1-T021** Export to Markdown (serialize Tiptap to MD via existing rules)
+- **W1-T022** Export to HTML (standalone page with doc content)
+- **W1-T023** Export to PDF (server-rendered via Vercel function with playwright-style renderer)
+- **W1-T024** Snapshot URL: frozen HTML view, shareable, indexed
+- **W1-T025** Export modal + format picker + trigger
+
+### Track A5: Version history (~5 PRs)
+
+- **W1-T026** Migration: `document_snapshots` table (doc_id, content jsonb, created_at, author)
+- **W1-T027** Snapshot on save (debounced to 5m per doc) and on major milestones (agent finishes plan, user hits save-snapshot)
+- **W1-T028** History panel UI: list of snapshots with timestamps and authors
+- **W1-T029** Diff view: two snapshots side-by-side, Tiptap-aware diff highlighting
+- **W1-T030** Restore snapshot (creates new snapshot, applies content)
+
+### Track A6: Search + org (~4 PRs)
+
+- **W1-T031** Full-text search across user's docs (postgres tsvector on content and title)
+- **W1-T032** Search UI + command palette
+- **W1-T033** Keyboard shortcuts: jump to doc, new doc, open search
+- **W1-T034** Recent docs list on HomeDashboard, sorted by last-modified
+
+## User stories
+
+_To be populated by ChatPRD._
+
+## Acceptance criteria per task
+
+_To be populated by ChatPRD. One block per task ID above._
+
+## Success metrics
+
+_To be populated by ChatPRD._
+
+## Open questions
+
+_To be populated by ChatPRD._

--- a/orchestration/wave-2-prd.md
+++ b/orchestration/wave-2-prd.md
@@ -1,0 +1,68 @@
+# Wave 2 PRD — Agent depth (Quadrant B)
+
+> This is a stub. Full PRD to be generated via ChatPRD MCP at wave-entry time and pasted here.
+
+## Wave goal
+
+Agents become materially smarter. Memory, planning, tools, surfaced disagreement.
+
+## Tasks in scope
+
+### Track B1: Persistent memory (~7 PRs)
+
+- **W2-T001** Migration: `agent_memories` (agent_id, project_id, kind, content, embedding, created_at)
+- **W2-T002** Memory write: end-of-session agent extracts "what I learned about this project" to memory
+- **W2-T003** Memory retrieval at prompt-build time: kNN over embedding, top-k injected
+- **W2-T004** Per-user memory (cross-project): "preferences" memory kind
+- **W2-T005** Memory UI: view/edit/delete per-agent memories
+- **W2-T006** Forget command in chat ("forget X")
+- **W2-T007** Embedding provider (Gemini embedding endpoint) + cost-guard
+
+### Track B2: Planning step (~5 PRs)
+
+- **W2-T008** Plan schema: `AgentPlan = { steps: [{ id, action, rationale }] }`
+- **W2-T009** `askAgentForPlan()` entrypoint before multi-step tasks
+- **W2-T010** Plan UI: card in timeline showing plan steps, edit before approve
+- **W2-T011** Approve plan → execute step-by-step; human can interject per step
+- **W2-T012** Plan replay: re-run an approved plan in a new doc
+
+### Track B3: Tool use beyond editor (~8 PRs)
+
+- **W2-T013** Tool protocol: `AgentTool = { name, description, schema, invoke }`; register tools per session
+- **W2-T014** Web search tool (Exa, via MCP if available, else HTTP)
+- **W2-T015** URL fetch tool (fetch and summarize a URL)
+- **W2-T016** Project retrieval tool (search other docs in same project)
+- **W2-T017** Code execution tool via Vercel Sandbox
+- **W2-T018** Tool result rendering in chat + insertable into doc
+- **W2-T019** Tool permission prompt: user approves first use per tool per session
+- **W2-T020** Tool usage telemetry
+
+### Track B4: Inter-agent disagreement (~4 PRs)
+
+- **W2-T021** Disagreement detection: when agents' next actions conflict or contradict
+- **W2-T022** Disagreement card UI: both positions visible, human picks
+- **W2-T023** Record resolution as memory for each agent
+- **W2-T024** Timeline entry for disagreements
+
+### Track B5: Multi-turn tool use (~4 PRs)
+
+- **W2-T025** Agent loop: propose tool → get result → reason → next action (up to N turns)
+- **W2-T026** Budget: tokens + tool-calls per task, enforced
+- **W2-T027** Early-exit: agent can hand back control if stuck
+- **W2-T028** Per-agent BYO-key: persona can carry its own API key, fall back to platform
+
+## User stories
+
+_To be populated by ChatPRD._
+
+## Acceptance criteria per task
+
+_To be populated by ChatPRD. One block per task ID above._
+
+## Success metrics
+
+_To be populated by ChatPRD._
+
+## Open questions
+
+_To be populated by ChatPRD._

--- a/orchestration/wave-3-prd.md
+++ b/orchestration/wave-3-prd.md
@@ -1,0 +1,55 @@
+# Wave 3 PRD — Openness (Quadrant C)
+
+> This is a stub. Full PRD to be generated via ChatPRD MCP at wave-entry time and pasted here.
+
+## Wave goal
+
+Any agent can join via open protocol. Persona portability. Provider abstraction lands.
+
+## Tasks in scope
+
+### Track C1: MCP server (~8 PRs)
+
+- **W3-T001** MCP server scaffold at `api/mcp/[...route].ts` (Vercel function)
+- **W3-T002** Authentication: per-user MCP token (issue/revoke in settings)
+- **W3-T003** Tool: `doc.read` — returns current doc content (Markdown)
+- **W3-T004** Tool: `doc.edit` — apply a Tiptap-compatible edit
+- **W3-T005** Tool: `doc.comment` — add a comment
+- **W3-T006** Tool: `session.list` — list user's sessions in a project
+- **W3-T007** External-agent presence: show MCP-joined agents in cursor layer with distinct avatar
+- **W3-T008** MCP rate limiting per token
+
+### Track C2: Persona portability (~5 PRs)
+
+- **W3-T009** Persona JSON schema (avatar, color, system prompt, tools, memory-scope)
+- **W3-T010** Export persona from AgentConfigurator
+- **W3-T011** Import persona via URL or paste
+- **W3-T012** Public-share persona link
+- **W3-T013** Persona marketplace page (static list of shared personas, read-only)
+
+### Track C3: Provider abstraction full landing (~3 PRs)
+
+- **W3-T014** Claude provider adapter
+- **W3-T015** OpenAI provider adapter
+- **W3-T016** Per-persona provider selector in AgentConfigurator
+
+### Track C4: Developer surface (~2 PRs)
+
+- **W3-T017** Public changelog page at `/changelog` (markdown source, static)
+- **W3-T018** Dev docs page at `/docs` (MCP tools, persona format, API key usage)
+
+## User stories
+
+_To be populated by ChatPRD._
+
+## Acceptance criteria per task
+
+_To be populated by ChatPRD. One block per task ID above._
+
+## Success metrics
+
+_To be populated by ChatPRD._
+
+## Open questions
+
+_To be populated by ChatPRD._

--- a/orchestration/wave-4-prd.md
+++ b/orchestration/wave-4-prd.md
@@ -1,0 +1,53 @@
+# Wave 4 PRD — Launch (Quadrant D)
+
+> This is a stub. Full PRD to be generated via ChatPRD MCP at wave-entry time and pasted here.
+
+## Wave goal
+
+Shipped product. Landing, onboarding, pricing, analytics, waitlist. Mostly serial; coordinate with ChatPRD for copy.
+
+## Tasks in scope
+
+### Track D1: Landing + marketing (~5 PRs)
+
+- **W4-T001** Landing hero rewrite (new value prop, demo video embed)
+- **W4-T002** Three-use-case section (drafting specs, collaborative brainstorm, agent-assisted review)
+- **W4-T003** Agent showcase (live demo embedded, not just screenshot)
+- **W4-T004** Social proof / design polish pass
+- **W4-T005** Demo video production (90s, scripted, produced externally; this PR embeds)
+
+### Track D2: Onboarding (~4 PRs)
+
+- **W4-T006** First-run flow: guided first doc with default agent speaking first
+- **W4-T007** Invite-agent nudge (if user hasn't added an agent after 60s)
+- **W4-T008** Sample project preloaded with a short demo doc
+- **W4-T009** Onboarding completion analytics event
+
+### Track D3: Pricing + waitlist (~4 PRs)
+
+- **W4-T010** Pricing page (free + paid tier, simple)
+- **W4-T011** Paid tier gating (usage caps enforced server-side)
+- **W4-T012** Waitlist signup (email capture) with invite-code gate
+- **W4-T013** First-100 ramp admin panel (approve waitlist entries)
+
+### Track D4: Analytics + observability (~3 PRs)
+
+- **W4-T014** PostHog event map: doc_create, agent_invoke, agent_reply, share, export, signup, first_doc_complete
+- **W4-T015** Langfuse trace enrichment: per-task labels
+- **W4-T016** Health dashboard (admin-only): daily actives, agent errors, rate-limit hits
+
+## User stories
+
+_To be populated by ChatPRD._
+
+## Acceptance criteria per task
+
+_To be populated by ChatPRD. One block per task ID above._
+
+## Success metrics
+
+_To be populated by ChatPRD._
+
+## Open questions
+
+_To be populated by ChatPRD._


### PR DESCRIPTION
## What
- Adds four PRD stub files under `orchestration/`, one per wave (wave-1 through wave-4).
- Each stub carries the wave goal copied from `orchestration/plan.md`, the full task list for that wave, and empty sections (user stories, acceptance criteria per task, success metrics, open questions) ready for ChatPRD output.
- Each stub begins with a note: "This is a stub. Full PRD to be generated via ChatPRD MCP at wave-entry time and pasted here."

## Why
Task W0-T015 in `orchestration/plan.md`: wave PRD infrastructure. These stubs let the orchestrator (or Oliver) run ChatPRD against each wave at wave-entry time and paste the output into the corresponding file without re-deriving scope.

## Acceptance
- [x] Four wave PRD stub files exist under `orchestration/`
- [x] Each lists the wave's tasks from `plan.md`
- [x] Each has empty sections ready for ChatPRD output
- [x] No code changed

## Verification
- `npm run lint` passes (unaffected by docs-only change).
- `git diff --stat` confirms only four new markdown files.

## Risk
low — documentation only, no code or config touched.

## Task
`W0-T015` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
