### PR TITLE
refactor: extract turn queue from orchestrator.ts (W0-T002)

### DIFF
--- a/src/__tests__/turn-queue.test.ts
+++ b/src/__tests__/turn-queue.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest'
+import { createTurnQueue, type TurnRequest } from '../orchestrator/turn-queue'
+
+const agents = [
+  { name: 'Aiden' },
+  { name: 'Nova' },
+]
+
+function req(agent: string, overrides: Partial<TurnRequest> = {}): TurnRequest {
+  return { agent, trigger: 'instruction', ...overrides }
+}
+
+describe('createTurnQueue', () => {
+  describe('enqueue / dequeue', () => {
+    it('push returns new queue length and FIFO order is preserved on shift', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.push(req('Aiden'))).toBe(1)
+      expect(q.push(req('Nova'))).toBe(2)
+      expect(q.push(req('Aiden', { instruction: 'third' }))).toBe(3)
+
+      expect(q.size()).toBe(3)
+      expect(q.shift()?.agent).toBe('Aiden')
+      expect(q.shift()?.agent).toBe('Nova')
+      expect(q.shift()?.instruction).toBe('third')
+      expect(q.shift()).toBeUndefined()
+      expect(q.size()).toBe(0)
+    })
+
+    it('clear empties the queue without disturbing counters', () => {
+      const q = createTurnQueue({ agents })
+      q.push(req('Aiden'))
+      q.push(req('Nova'))
+      q.incrementTurnCount('Aiden')
+      q.incrementExchange()
+
+      q.clear()
+      expect(q.size()).toBe(0)
+      expect(q.getTurnCount('Aiden')).toBe(1)
+      expect(q.getExchangeCount()).toBe(1)
+    })
+
+    it('removeAgent deletes every pending request for an agent and preserves the rest', () => {
+      const q = createTurnQueue({ agents })
+      q.push(req('Aiden'))
+      q.push(req('Nova'))
+      q.push(req('Aiden', { instruction: 'again' }))
+      q.push(req('Nova', { instruction: 'later' }))
+
+      q.removeAgent('Aiden')
+      expect(q.size()).toBe(2)
+      expect(q.hasAgent('Aiden')).toBe(false)
+      expect(q.hasAgent('Nova')).toBe(true)
+      expect(q.shift()?.agent).toBe('Nova')
+      expect(q.shift()?.instruction).toBe('later')
+    })
+
+    it('hasAgent reflects current queue membership', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.hasAgent('Aiden')).toBe(false)
+      q.push(req('Aiden'))
+      expect(q.hasAgent('Aiden')).toBe(true)
+      q.shift()
+      expect(q.hasAgent('Aiden')).toBe(false)
+    })
+  })
+
+  describe('processing flag', () => {
+    it('defaults to false and toggles on setProcessing', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.isProcessing()).toBe(false)
+      q.setProcessing(true)
+      expect(q.isProcessing()).toBe(true)
+      q.setProcessing(false)
+      expect(q.isProcessing()).toBe(false)
+    })
+
+    it('reset releases the processing flag', () => {
+      const q = createTurnQueue({ agents })
+      q.setProcessing(true)
+      q.reset()
+      expect(q.isProcessing()).toBe(false)
+    })
+  })
+
+  describe('turnCount', () => {
+    it('seeds zero counts for agents passed at construction', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.getTurnCount('Aiden')).toBe(0)
+      expect(q.getTurnCount('Nova')).toBe(0)
+    })
+
+    it('returns 0 for unknown agents without mutating state', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.getTurnCount('Ghost')).toBe(0)
+    })
+
+    it('incrementTurnCount increments only the targeted agent', () => {
+      const q = createTurnQueue({ agents })
+      q.incrementTurnCount('Aiden')
+      q.incrementTurnCount('Aiden')
+      q.incrementTurnCount('Nova')
+      expect(q.getTurnCount('Aiden')).toBe(2)
+      expect(q.getTurnCount('Nova')).toBe(1)
+    })
+
+    it('ensureAgent seeds new agents at zero and is idempotent for known agents', () => {
+      const q = createTurnQueue({ agents })
+      q.incrementTurnCount('Aiden')
+      q.ensureAgent('Aiden')
+      expect(q.getTurnCount('Aiden')).toBe(1)
+
+      q.ensureAgent('Lex')
+      expect(q.getTurnCount('Lex')).toBe(0)
+      q.incrementTurnCount('Lex')
+      expect(q.getTurnCount('Lex')).toBe(1)
+    })
+
+    it('resetTurnCounts zeroes every seeded counter', () => {
+      const q = createTurnQueue({ agents })
+      q.incrementTurnCount('Aiden')
+      q.incrementTurnCount('Nova')
+      q.incrementTurnCount('Nova')
+      q.resetTurnCounts()
+      expect(q.getTurnCount('Aiden')).toBe(0)
+      expect(q.getTurnCount('Nova')).toBe(0)
+    })
+
+    it('isTurnLimitReached reflects the current count versus the cap', () => {
+      const q = createTurnQueue({ agents })
+      q.incrementTurnCount('Aiden')
+      expect(q.isTurnLimitReached('Aiden', 2)).toBe(false)
+      q.incrementTurnCount('Aiden')
+      expect(q.isTurnLimitReached('Aiden', 2)).toBe(true)
+      expect(q.isTurnLimitReached('Nova', 2)).toBe(false)
+    })
+  })
+
+  describe('exchangeCount', () => {
+    it('starts at zero and increments', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.getExchangeCount()).toBe(0)
+      q.incrementExchange()
+      q.incrementExchange()
+      expect(q.getExchangeCount()).toBe(2)
+    })
+
+    it('resetExchangeCount returns the counter to zero', () => {
+      const q = createTurnQueue({ agents })
+      q.incrementExchange()
+      q.incrementExchange()
+      q.resetExchangeCount()
+      expect(q.getExchangeCount()).toBe(0)
+    })
+
+    it('isExchangeLimitReached caps at maxExchanges inclusively', () => {
+      const q = createTurnQueue({ agents })
+      expect(q.isExchangeLimitReached(2)).toBe(false)
+      q.incrementExchange()
+      expect(q.isExchangeLimitReached(2)).toBe(false)
+      q.incrementExchange()
+      expect(q.isExchangeLimitReached(2)).toBe(true)
+    })
+  })
+
+  describe('reset semantics', () => {
+    it('reset clears queue, processing, counts, and exchange counter', () => {
+      const q = createTurnQueue({ agents })
+      q.push(req('Aiden'))
+      q.push(req('Nova'))
+      q.setProcessing(true)
+      q.incrementTurnCount('Aiden')
+      q.incrementTurnCount('Nova')
+      q.incrementExchange()
+
+      q.reset()
+
+      expect(q.size()).toBe(0)
+      expect(q.isProcessing()).toBe(false)
+      expect(q.getTurnCount('Aiden')).toBe(0)
+      expect(q.getTurnCount('Nova')).toBe(0)
+      expect(q.getExchangeCount()).toBe(0)
+    })
+
+    it('reset is safe on an already-empty queue', () => {
+      const q = createTurnQueue({ agents })
+      q.reset()
+      expect(q.size()).toBe(0)
+      expect(q.isProcessing()).toBe(false)
+    })
+
+    it('state survives until reset — no implicit cleanup on shift', () => {
+      const q = createTurnQueue({ agents })
+      q.push(req('Aiden'))
+      q.incrementTurnCount('Aiden')
+      q.incrementExchange()
+      q.shift()
+      // Shifting a turn should NOT reset counters; reset must be explicit.
+      expect(q.getTurnCount('Aiden')).toBe(1)
+      expect(q.getExchangeCount()).toBe(1)
+    })
+  })
+
+  describe('instance isolation', () => {
+    it('two queues share no state', () => {
+      const a = createTurnQueue({ agents })
+      const b = createTurnQueue({ agents })
+      a.push(req('Aiden'))
+      a.incrementTurnCount('Aiden')
+      a.incrementExchange()
+      expect(b.size()).toBe(0)
+      expect(b.getTurnCount('Aiden')).toBe(0)
+      expect(b.getExchangeCount()).toBe(0)
+    })
+  })
+})

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -9,21 +9,12 @@ import { DEFAULT_LIMITS, DEFAULT_EXPERIMENTS, type OrchestratorLimits, type Agen
 import { type PhaseState, initialPhaseState, phaseReducer, isActionAllowed } from './phase-machine'
 import { getAgentMode } from './agent-modes'
 import { detectObservations, resetWizard } from './wizard-of-oz'
+import { createTurnQueue, type TurnRequest } from './orchestrator/turn-queue'
 
 export type { AgentConfig }
 
 type AgentName = string
 type TriggerType = 'doc-opened' | 'user-message' | 'agent-tagged' | 'turn-complete' | 'heartbeat'
-
-interface TurnRequest {
-  agent: AgentName
-  trigger: AskParams['trigger']
-  instruction?: string
-  /** When true, this turn originated from the welcome/doc-opened flow and should not count toward the exchange limit */
-  isInitial?: boolean
-  /** User-approved doc mutation (skips LLM; runs through verifier with allowDirectDocEdit) */
-  directAction?: AgentAction
-}
 
 interface OrchestratorConfig {
   getEditor: () => Editor | null
@@ -102,8 +93,7 @@ function approvedPayloadToAction(agent: string, payload: EditProposalPayload): A
 }
 
 export function createOrchestrator(config: OrchestratorConfig): OrchestratorHandle {
-  const queue: TurnRequest[] = []
-  let processing = false
+  const turnQueue = createTurnQueue({ agents: config.agents })
   let destroyed = false
   const editorLockRef: { current: string | null } = { current: null }
   const typingTimers: Record<string, number> = {}
@@ -133,10 +123,6 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
     if (experiments.verboseLogging) console.log('[orch:verbose]', ...args)
   }
 
-  // Track total turns per agent (caps all non-user-initiated work)
-  const turnCount: Record<string, number> = Object.fromEntries(config.agents.map(a => [a.name, 0]))
-  // Track back-and-forth exchanges
-  let exchangeCount = 0
   // Track pending doc-edit reaction to prevent double-triggers
   let pendingReaction: AgentName | null = null
   // Round-robin index for balanced agent selection
@@ -187,25 +173,25 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
       return
     }
     log('enqueue', req.agent, req.trigger, req.instruction?.slice(0, 40))
-    vlog('enqueue detail', { agent: req.agent, trigger: req.trigger, queueBefore: queue.length, processing })
-    queue.push(req)
+    vlog('enqueue detail', { agent: req.agent, trigger: req.trigger, queueBefore: turnQueue.size(), processing: turnQueue.isProcessing() })
+    const depth = turnQueue.push(req)
     const sessionMatch = window.location.pathname.match(/\/s\/([^/]+)/)
     const sessionId = sessionMatch?.[1] || ''
-    events.orchestratorQueueDepth(sessionId, queue.length, processing ? 'processing' : null)
+    events.orchestratorQueueDepth(sessionId, depth, turnQueue.isProcessing() ? 'processing' : null)
     processQueue()
   }
 
   async function processQueue() {
-    if (processing || queue.length === 0 || destroyed) return
-    processing = true
+    if (turnQueue.isProcessing() || turnQueue.size() === 0 || destroyed) return
+    turnQueue.setProcessing(true)
 
-    const req = queue.shift()!
+    const req = turnQueue.shift()!
     const turnStartTime = Date.now()
-    log('processing', req.agent, req.trigger, 'queue:', queue.length)
+    log('processing', req.agent, req.trigger, 'queue:', turnQueue.size())
     const editor = config.getEditor()
     if (!editor) {
       log('no editor, skipping')
-      processing = false
+      turnQueue.setProcessing(false)
       return
     }
 
@@ -287,9 +273,9 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         consecutiveFailures[req.agent] = 0
         const actionDesc = describeAction(req.agent, action)
         lastActionDescription[req.agent] = actionDesc
-        turnCount[req.agent]++
+        turnQueue.incrementTurnCount(req.agent)
         if (pendingReaction === req.agent) pendingReaction = null
-        processing = false
+        turnQueue.setProcessing(false)
         const pending = pendingInstructions[req.agent]
         if (pending) {
           delete pendingInstructions[req.agent]
@@ -298,7 +284,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
             return
           }
         }
-        if (action.shouldContinue && turnCount[req.agent] < limits.maxTurns) {
+        if (action.shouldContinue && !turnQueue.isTurnLimitReached(req.agent, limits.maxTurns)) {
           enqueue({ agent: req.agent, trigger: 'autonomous' })
         } else {
           processQueue()
@@ -315,9 +301,9 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         }
         config.onAgentState(req.agent, 'idle')
         consecutiveFailures[req.agent] = 0
-        turnCount[req.agent]++
+        turnQueue.incrementTurnCount(req.agent)
         if (pendingReaction === req.agent) pendingReaction = null
-        processing = false
+        turnQueue.setProcessing(false)
         processQueue()
         return
       }
@@ -330,7 +316,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           if (!destroyed) config.onChatMessage(from, text)
         },
         onDone: (success?: boolean) => {
-          if (destroyed) { processing = false; return }
+          if (destroyed) { turnQueue.setProcessing(false); return }
           consecutiveFailures[req.agent] = 0
           log('done', req.agent, action.type, 'success:', success, 'shouldContinue:', action.shouldContinue)
           const durationMs = Date.now() - turnStartTime
@@ -339,7 +325,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           events.orchestratorTurn(sessionId, req.agent, req.trigger, action.type, success !== false, durationMs)
           const actionDesc = describeAction(req.agent, action)
           lastActionDescription[req.agent] = actionDesc
-          turnCount[req.agent]++
+          turnQueue.incrementTurnCount(req.agent)
           // Handle rename action
           if (action.type === 'rename' && action.newTitle && config.onRenameSession) {
             config.onRenameSession(action.newTitle)
@@ -354,7 +340,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
             config.onDocAction?.(req.agent, actionDesc)
           }
           if (pendingReaction === req.agent) pendingReaction = null
-          processing = false
+          turnQueue.setProcessing(false)
 
           // Process queued instruction — but skip if it's the same one we just ran
           const pending = pendingInstructions[req.agent]
@@ -368,15 +354,15 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
           // After a SUCCESSFUL doc edit, prompt the OTHER agent to react
           const didEdit = (action.type === 'insert' || action.type === 'replace' || action.type === 'image') && success !== false
-          if (didEdit && queue.length === 0) {
+          if (didEdit && turnQueue.size() === 0) {
             // Round-robin routing: rotate through other agents for balanced participation
             const otherNames = agentNames.filter(n => n !== req.agent)
             const other: AgentName = otherNames[reactionRoundRobin % otherNames.length] || agentNames[0]
             reactionRoundRobin++
             // Initial (welcome/doc-opened) reactions don't count toward the exchange limit
             const countsAsExchange = !req.isInitial
-            if (other !== req.agent && (countsAsExchange ? exchangeCount < limits.maxExchanges : true) && turnCount[other] < limits.maxTurns && pendingReaction !== other) {
-              if (countsAsExchange) exchangeCount++
+            if (other !== req.agent && (countsAsExchange ? !turnQueue.isExchangeLimitReached(limits.maxExchanges) : true) && !turnQueue.isTurnLimitReached(other, limits.maxTurns) && pendingReaction !== other) {
+              if (countsAsExchange) turnQueue.incrementExchange()
               pendingReaction = other
               const otherCfg = getAgentConfig(other)
               const reactionInstruction = buildReactionInstruction(req.agent, actionDesc, action.type, otherCfg?.persona || '')
@@ -389,7 +375,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
                 })
               }, limits.reactionDelayMs[0] + Math.random() * (limits.reactionDelayMs[1] - limits.reactionDelayMs[0]))
             }
-          } else if (action.shouldContinue && turnCount[req.agent] < limits.maxTurns) {
+          } else if (action.shouldContinue && !turnQueue.isTurnLimitReached(req.agent, limits.maxTurns)) {
             enqueue({ agent: req.agent, trigger: 'autonomous' })
           } else {
             processQueue()
@@ -400,7 +386,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
       vlog('executing', req.agent, action.type, action.position || '')
       executeAgentAction(editor, req.agent, agentCfg?.color || '#1a1a1a', action, editorLockRef, typingTimers, callbacks, experiments.insertStrategy)
     } catch (err) {
-      if (destroyed) { processing = false; return }
+      if (destroyed) { turnQueue.setProcessing(false); return }
       log('error', req.agent, err)
       consecutiveFailures[req.agent]++
       const failures = consecutiveFailures[req.agent]
@@ -417,13 +403,11 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
       if (failures >= limits.maxConsecutiveFailures) {
         log(`pausing ${req.agent} after ${failures} consecutive failures`)
         pausedAgents.add(req.agent)
-        for (let i = queue.length - 1; i >= 0; i--) {
-          if (queue[i].agent === req.agent) queue.splice(i, 1)
-        }
+        turnQueue.removeAgent(req.agent)
       }
 
       config.onAgentState(req.agent, 'idle')
-      processing = false
+      turnQueue.setProcessing(false)
       processQueue()
     }
   }
@@ -454,10 +438,8 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
     switch (type) {
       case 'doc-opened': {
-        for (const name of agentNames) {
-          turnCount[name] = 0
-        }
-        exchangeCount = 0
+        turnQueue.resetTurnCounts()
+        turnQueue.resetExchangeCount()
         pendingReaction = null
 
         // Classify doc state and decide session phase
@@ -524,12 +506,12 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         const mentionsBoth = mentionedAgents.length === 0
 
         // User messages take priority — clear everything
-        queue.length = 0
+        turnQueue.clear()
         for (const name of agentNames) delete pendingInstructions[name]
         // Cancel all pending reaction timeouts
         scheduledTimers.forEach(id => clearTimeout(id))
         scheduledTimers.clear()
-        exchangeCount = 0
+        turnQueue.resetExchangeCount()
         pendingReaction = null
         // Unpause agents on user interaction so they can retry
         pausedAgents.clear()
@@ -537,7 +519,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
         const agentsToTrigger = mentionsBoth ? agentNames : mentionedAgents
         for (const name of agentsToTrigger) {
-          if (processing) {
+          if (turnQueue.isProcessing()) {
             pendingInstructions[name] = { trigger: 'instruction', instruction }
           } else {
             enqueue({ agent: name, trigger: 'instruction', instruction })
@@ -554,12 +536,12 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           log('agent-tagged skipped — already has pending reaction', target)
           break
         }
-        if (exchangeCount >= limits.maxExchanges) {
+        if (turnQueue.isExchangeLimitReached(limits.maxExchanges)) {
           log('exchange limit reached, ignoring agent tag')
           break
         }
-        if (target && turnCount[target] < limits.maxTurns) {
-          exchangeCount++
+        if (target && !turnQueue.isTurnLimitReached(target, limits.maxTurns)) {
+          turnQueue.incrementExchange()
           enqueue({ agent: target, trigger: 'instruction', instruction: `${from} just mentioned you in chat. Read the recent chat and respond to their latest message.` })
         }
         break
@@ -603,7 +585,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
   async function fireHeartbeat() {
     if (destroyed || agentNames.length === 0) return
-    if (processing) {
+    if (turnQueue.isProcessing()) {
       startHeartbeat()
       return
     }
@@ -611,7 +593,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
     const docText = config.getDocText()
     const recentMessages = config.getMessages().slice(-10)
     const availableAgents = config.agents.filter(agent =>
-      !pausedAgents.has(agent.name) && !queue.some(q => q.agent === agent.name)
+      !pausedAgents.has(agent.name) && !turnQueue.hasAgent(agent.name)
     )
 
     const scriptedObservation = detectObservations(
@@ -669,16 +651,13 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
     resetRateLimiter()
     resetHeartbeat()
     resetWizard()
-    queue.length = 0
-    processing = false
+    turnQueue.reset()
     editorLockRef.current = null
     for (const name of agentNames) {
-      turnCount[name] = 0
       consecutiveFailures[name] = 0
       delete pendingInstructions[name]
     }
     lastActionDescription = {}
-    exchangeCount = 0
     pendingReaction = null
     reactionRoundRobin = 0
     pausedAgents.clear()

--- a/src/orchestrator/turn-queue.ts
+++ b/src/orchestrator/turn-queue.ts
@@ -1,0 +1,163 @@
+import type { AgentAction, AskParams } from '../agent'
+
+type AgentName = string
+
+/**
+ * A pending turn request held by the orchestrator's queue.
+ * Matches the shape used by the orchestrator's dispatch loop.
+ */
+export interface TurnRequest {
+  agent: AgentName
+  trigger: AskParams['trigger']
+  instruction?: string
+  /** When true, this turn originated from the welcome/doc-opened flow and should not count toward the exchange limit */
+  isInitial?: boolean
+  /** User-approved doc mutation (skips LLM; runs through verifier with allowDirectDocEdit) */
+  directAction?: AgentAction
+}
+
+export interface TurnQueueOptions {
+  /** Initial agent roster used to seed per-agent turn counters. */
+  agents: ReadonlyArray<{ name: AgentName }>
+}
+
+/**
+ * Public interface of the turn queue. The orchestrator composes this to manage
+ * queue state (pending turns), the processing mutex, per-agent turn counts,
+ * and the inter-agent exchange counter.
+ *
+ * All behavior is identical to the prior inline implementation — this module
+ * purely encapsulates state and helpers; policy (when to enqueue, when to skip,
+ * analytics emission, pause logic) remains in the orchestrator.
+ */
+export interface TurnQueue {
+  /** Push a request onto the tail of the queue. Returns new queue length. */
+  push(req: TurnRequest): number
+  /** Shift the next request from the head of the queue (undefined when empty). */
+  shift(): TurnRequest | undefined
+  /** Current queue depth. */
+  size(): number
+  /** Clear all pending requests. */
+  clear(): void
+  /** Remove every pending request belonging to an agent (used when pausing on failures). */
+  removeAgent(agent: AgentName): void
+  /** True when any pending request targets the given agent. */
+  hasAgent(agent: AgentName): boolean
+
+  /** Processing mutex — true while a turn is in-flight. */
+  isProcessing(): boolean
+  setProcessing(value: boolean): void
+
+  /** Increment the per-agent turn counter. */
+  incrementTurnCount(agent: AgentName): void
+  /** Read the per-agent turn counter (0 for unknown agents). */
+  getTurnCount(agent: AgentName): number
+  /** Reset every known agent's turn counter to 0. */
+  resetTurnCounts(): void
+  /** Ensure an agent has a counter slot (initialized to 0 if absent). */
+  ensureAgent(agent: AgentName): void
+
+  /** Increment the back-and-forth exchange counter. */
+  incrementExchange(): void
+  /** Read the exchange counter. */
+  getExchangeCount(): number
+  /** Reset the exchange counter to 0. */
+  resetExchangeCount(): void
+
+  /** True when an agent has hit or passed the turn cap. */
+  isTurnLimitReached(agent: AgentName, maxTurns: number): boolean
+  /** True when exchanges have hit or passed the exchange cap. */
+  isExchangeLimitReached(maxExchanges: number): boolean
+
+  /**
+   * Reset every piece of state: empties the queue, releases the processing flag,
+   * zeroes turn counts, and resets the exchange counter. Intended for destroy().
+   */
+  reset(): void
+}
+
+/**
+ * Factory mirroring the `createRateLimiter` pattern: returns a typed interface
+ * backed by closed-over state. No globals, no singletons — each orchestrator
+ * instance owns its own queue.
+ */
+export function createTurnQueue(options: TurnQueueOptions): TurnQueue {
+  const queue: TurnRequest[] = []
+  let processing = false
+  let exchangeCount = 0
+  const turnCount: Record<string, number> = Object.fromEntries(
+    options.agents.map(a => [a.name, 0]),
+  )
+
+  return {
+    push(req) {
+      queue.push(req)
+      return queue.length
+    },
+    shift() {
+      return queue.shift()
+    },
+    size() {
+      return queue.length
+    },
+    clear() {
+      queue.length = 0
+    },
+    removeAgent(agent) {
+      for (let i = queue.length - 1; i >= 0; i--) {
+        if (queue[i].agent === agent) queue.splice(i, 1)
+      }
+    },
+    hasAgent(agent) {
+      return queue.some(q => q.agent === agent)
+    },
+
+    isProcessing() {
+      return processing
+    },
+    setProcessing(value) {
+      processing = value
+    },
+
+    incrementTurnCount(agent) {
+      turnCount[agent] = (turnCount[agent] ?? 0) + 1
+    },
+    getTurnCount(agent) {
+      return turnCount[agent] ?? 0
+    },
+    resetTurnCounts() {
+      for (const name of Object.keys(turnCount)) {
+        turnCount[name] = 0
+      }
+    },
+    ensureAgent(agent) {
+      if (!(agent in turnCount)) turnCount[agent] = 0
+    },
+
+    incrementExchange() {
+      exchangeCount++
+    },
+    getExchangeCount() {
+      return exchangeCount
+    },
+    resetExchangeCount() {
+      exchangeCount = 0
+    },
+
+    isTurnLimitReached(agent, maxTurns) {
+      return (turnCount[agent] ?? 0) >= maxTurns
+    },
+    isExchangeLimitReached(maxExchanges) {
+      return exchangeCount >= maxExchanges
+    },
+
+    reset() {
+      queue.length = 0
+      processing = false
+      exchangeCount = 0
+      for (const name of Object.keys(turnCount)) {
+        turnCount[name] = 0
+      }
+    },
+  }
+}


### PR DESCRIPTION
## What
- New `src/orchestrator/turn-queue.ts` exporting `createTurnQueue(options)` factory + typed `TurnQueue` / `TurnRequest` interfaces.
- `src/orchestrator.ts` now composes the turn queue for pending turns, the processing mutex, per-agent turn counts, and the exchange counter. Public API and external behavior unchanged.
- New `src/__tests__/turn-queue.test.ts` with 19 tests covering enqueue/dequeue/clear/removeAgent/hasAgent, the processing flag, turnCount increment / reset / ensureAgent / limit check, exchangeCount increment / reset / limit check, reset semantics, and instance isolation.

## Why
Task `W0-T002` — extract the turn-queue state machine as the first incremental decomposition of the orchestrator god-module. Mirrors the rate-limiter extraction pattern (W0-T004) and sets up downstream splits (heartbeat W0-T003, reaction round-robin W0-T006, editor-lock W0-T007).

## Acceptance
- [x] `src/orchestrator/turn-queue.ts` exports factory + typed interface
- [x] `src/orchestrator.ts` imports and uses it; behavior unchanged
- [x] New test file covers enqueue/dequeue/processing/turnCount/exchangeCount
- [x] lint + typecheck + test + build all green
- [x] No other files modified beyond orchestrator.ts + new files

## Verification
Locally on the worktree branch:
- `npm run lint` — passes (no warnings)
- `npm run typecheck` — passes
- `npm test` — 185/185 passing across 11 files (was 166/166 across 10 files; +19 tests from `turn-queue.test.ts`)
- `npm run build` — passes (Vite build 3.35s)
- `orchestrator.test.ts` — 31/31 still passing (no regression in existing suite)
- `orchestrator.ts` LOC: 690 -> 669 (−21 lines net)

## Risk
**Low.** Pure state-ownership refactor. The extracted module only encapsulates storage + helpers — all policy (when to enqueue, pause logic, analytics emission, reaction routing) stays in `orchestrator.ts` and reads/writes through the same semantic operations. Full orchestrator test suite (including exchange-limit, turn-limit, failure-pause, and destroy flows) passes unchanged.

## Task
`W0-T002` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
