### PR TITLE
refactor: extract useSessionState hook and remove callbacksRef bridge (W0-T009)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,8 @@ import { resolvePresetTasks } from './task-presets'
 // Custom hooks
 import { useOrchestrator } from './hooks/useOrchestrator'
 import { useSession, now, uid } from './hooks/useSession'
-import { useMarkupEditor, type MarkupEditorCallbacks } from './hooks/use-markup-editor'
+import { useMarkupEditor } from './hooks/use-markup-editor'
+import { useSessionState } from './hooks/use-session-state'
 
 
 /** How long "Saved" stays visible in the header before fading. */
@@ -79,52 +80,55 @@ function App() {
   const [experimentSettings, setExperimentSettings] = useState<ExperimentSettings>({ ...DEFAULT_EXPERIMENTS })
   const [geminiApiKey, setGeminiApiKey] = useState('')
   const [driveStatus, setDriveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
-  const [agentStates, setAgentStates] = useState<Record<string, AgentState>>({})
   const getAgentState = (name: string): AgentState => agentStates[name] || { status: 'idle', inDoc: false }
   const [timeline, setTimeline] = useState<TimelineEntry[]>([])
 
   // Stable orchestrator ref -- shared between useMarkupEditor, useSession, and useOrchestrator
   const orchestratorRef = useRef<ReturnType<typeof import('./orchestrator').createOrchestrator> | null>(null)
 
-  // Session callbacks ref -- populated after useSession runs so the editor's
-  // debounced save can read the latest session getter/setter.
-  const editorCallbacksRef = useRef<MarkupEditorCallbacks>({ getActiveSession: null, setActiveSession: null })
+  // Session state hook -- owns activeSession/messages/tasks/agentStates +
+  // their setters and mirror refs. Called first so useMarkupEditor can
+  // consume activeSessionRef/setActiveSession directly.
+  const {
+    activeSession, setActiveSession, activeSessionRef,
+    messages, setMessages, messagesRef,
+    tasks, setTasks, tasksRef,
+    agentStates, setAgentStates,
+  } = useSessionState()
 
   // Editor hook owns the Tiptap instance, extensions, save debounce, and user-edit detection.
   const { editor, editorRef, lastDocSnapshot } = useMarkupEditor({
     isViewMode,
     orchestratorRef,
     setSaveStatus,
-    callbacksRef: editorCallbacksRef,
+    activeSessionRef,
+    setActiveSession,
     toast,
     docSaveDebounceMs: DOC_SAVE_DEBOUNCE_MS,
     docEditReactDebounceMs: DOC_EDIT_REACT_DEBOUNCE_MS,
     savedStatusFadeMs: SAVED_STATUS_FADE_MS,
   })
 
-  // Chat state
-  const [messages, setMessages] = useState<import('./types').Message[]>([])
+  // Chat input is local UI state, not session-scoped.
   const [input, setInput] = useState('')
-  const messagesRef = useRef(messages)
-  useEffect(() => { messagesRef.current = messages })
   const lastProcessedMsg = useRef(0)
 
-  // Task state
-  const [tasks, setTasks] = useState<AgentTask[]>([])
-  const tasksRef = useRef(tasks)
-  useEffect(() => { tasksRef.current = tasks })
+  // Work plan + pending starter are modal-scoped; belong alongside input.
   const [workPlan, setWorkPlan] = useState<{ presetId: string; presetTitle: string; tasks: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor' | 'order'>[] } | null>(null)
   const pendingStarterRef = useRef<{ id: string; title: string; template: import('./types').DocTemplate; agents: import('./types').AgentConfig[] } | null>(null)
 
-  // Session hook
+  // Session flow hook -- owns hydration, URL routing, template picking.
+  // Reads/writes session state via the refs + setters from useSessionState.
   const {
-    activeSession, setActiveSession, activeSessionRef,
     sessions, setSessions, sessionsLoaded,
     activeAgents, setActiveAgents,
     handleSessionSelect, handleTemplatePick, handleGoogleImport,
     resetToHome,
   } = useSession({
     editor,
+    activeSession,
+    setActiveSession,
+    activeSessionRef,
     setMessages,
     setTimeline,
     setAgentStates,
@@ -135,17 +139,6 @@ function App() {
     messagesRef,
     setTasks,
     suppressDocHydrateRef,
-  })
-
-  // Wire the session callbacks into the editor hook's ref. Both `setActiveSession`
-  // and `activeSessionRef` are stable by identity, but we assign each render to
-  // keep the contract explicit — the editor's debounced save callback reads
-  // `.current` at fire time and always sees the latest session.
-  useEffect(() => {
-    editorCallbacksRef.current = {
-      getActiveSession: () => activeSessionRef.current,
-      setActiveSession,
-    }
   })
 
   // Task callbacks (must be after useSession for activeSessionRef)
@@ -172,7 +165,7 @@ function App() {
         },
       }])
     }
-  }, [setMessages])
+  }, [setMessages, setTasks, tasksRef])
 
   const handleAddTask = useCallback((task: Pick<AgentTask, 'title' | 'assignedAgents' | 'sectionAnchor'>) => {
     const session = activeSessionRef.current
@@ -189,7 +182,7 @@ function App() {
     saveAgentTasks(session.id, [newTask]).then(saved => {
       if (saved.length > 0) setTasks(prev => [...prev, ...saved])
     }).catch(console.error)
-  }, [activeSessionRef])
+  }, [activeSessionRef, setTasks, tasksRef])
 
   // Orchestrator hook -- populates orchestratorRef
   useOrchestrator({
@@ -232,7 +225,7 @@ function App() {
     const mentioned = activeAgents.filter(a => text.toLowerCase().includes(a.name.toLowerCase())).map(a => a.name)
     events.messageSent(session?.id || '', mentioned)
     orchestratorRef.current?.trigger('user-message', { instruction: text })
-  }, [input, activeSessionRef, orchestratorRef, activeAgents])
+  }, [input, activeSessionRef, orchestratorRef, activeAgents, setMessages])
 
   const handleSendSuggestion = useCallback((text: string) => {
     setMessages(m => [...m, { id: uid(), from: 'You', text, time: now() }])
@@ -244,7 +237,7 @@ function App() {
       )
     }
     orchestratorRef.current?.trigger('user-message', { instruction: text })
-  }, [activeSessionRef, orchestratorRef])
+  }, [activeSessionRef, orchestratorRef, setMessages])
 
   // Global keyboard shortcuts (extracted to hook)
   const togglePauseRef = useRef<() => void>(() => {})

--- a/src/hooks/use-markup-editor.ts
+++ b/src/hooks/use-markup-editor.ts
@@ -12,19 +12,6 @@ import type { createOrchestrator } from '../orchestrator'
 
 const EMPTY_DOC = '<h1>Untitled</h1><p></p>'
 
-/**
- * Mutable callbacks bag for {@link useMarkupEditor}. The hook reads these at
- * debounce-fire time (not at construction), so the caller can populate them
- * *after* sibling hooks (`useSession`) have created their setters. Any field
- * may be null until the caller wires it up.
- */
-export interface MarkupEditorCallbacks {
-  /** Session state getter — read at save-time, after debounce. */
-  getActiveSession: (() => Session | null) | null
-  /** Session title updater — called when the doc's H1 changes. */
-  setActiveSession: React.Dispatch<React.SetStateAction<Session | null>> | null
-}
-
 export interface UseMarkupEditorOptions {
   /** View mode makes the editor read-only and skips save/user-edit side effects. */
   isViewMode: boolean
@@ -33,11 +20,12 @@ export interface UseMarkupEditorOptions {
   /** Called when the save lifecycle transitions (saving → saved → idle). */
   setSaveStatus: React.Dispatch<React.SetStateAction<'saved' | 'saving' | 'idle'>>
   /**
-   * Ref holding the current session callbacks. The caller is responsible for
-   * updating `.current` each render so the editor's debounced save always
-   * reads the freshest setter/getter.
+   * Mirror ref of `activeSession`, read at debounce-fire time so the save
+   * callback always sees the latest session without restaging the editor.
    */
-  callbacksRef: React.RefObject<MarkupEditorCallbacks>
+  activeSessionRef: React.RefObject<Session | null>
+  /** Session state setter — called when the doc's H1 changes. */
+  setActiveSession: React.Dispatch<React.SetStateAction<Session | null>>
   /** Toast surface for user-facing save errors. */
   toast: (opts: { type: 'error'; message: string }) => void
   /** Debounce before persisting to Supabase after a keystroke. */
@@ -67,16 +55,17 @@ export interface UseMarkupEditorResult {
  * are intentionally *not* threaded through here — those belong in sibling
  * hooks.
  *
- * Session-facing callbacks are read lazily via {@link MarkupEditorCallbacks}
- * so the caller can create the editor before `useSession` has produced its
- * setters.
+ * `activeSessionRef` and `setActiveSession` are passed directly — they are
+ * owned by `useSessionState`, which is called before this hook so the refs
+ * are live by the time the editor mounts.
  */
 export function useMarkupEditor(options: UseMarkupEditorOptions): UseMarkupEditorResult {
   const {
     isViewMode,
     orchestratorRef,
     setSaveStatus,
-    callbacksRef,
+    activeSessionRef,
+    setActiveSession,
     toast,
     docSaveDebounceMs,
     docEditReactDebounceMs,
@@ -115,8 +104,7 @@ export function useMarkupEditor(options: UseMarkupEditorOptions): UseMarkupEdito
       if (docSaveTimer.current) clearTimeout(docSaveTimer.current)
       docSaveTimer.current = window.setTimeout(() => {
         setSaveStatus('saving')
-        const { getActiveSession, setActiveSession } = callbacksRef.current
-        const session = getActiveSession?.() ?? null
+        const session = activeSessionRef.current
         if (session) {
           saveDocument(session.id, ed.getHTML())
             .then(() => {
@@ -130,7 +118,7 @@ export function useMarkupEditor(options: UseMarkupEditorOptions): UseMarkupEdito
           const h1 = json.content?.find(n => n.type === 'heading' && n.attrs?.level === 1)
           const h1Text = h1?.content?.map(c => c.text || '').join('') || ''
           if (h1Text && h1Text !== session.title) {
-            setActiveSession?.(s => s ? { ...s, title: h1Text } : s)
+            setActiveSession(s => s ? { ...s, title: h1Text } : s)
             updateSessionTitle(session.id, h1Text).catch(err =>
               console.error('[App] updateSessionTitle error:', err)
             )

--- a/src/hooks/use-session-state.ts
+++ b/src/hooks/use-session-state.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react'
+import type { AgentState, AgentTask, Message, Session } from '../types'
+
+/**
+ * The piece of App-level state that every collaboration surface reads: the
+ * currently-open session, the chat stream, the task list, and each agent's
+ * live status. Owned by {@link useSessionState} so hooks like
+ * {@link useMarkupEditor} can receive the refs/setters directly without
+ * going through a mutable callback bag.
+ */
+export interface UseSessionStateResult {
+  /** Current session, or null if the user is on the home dashboard. */
+  activeSession: Session | null
+  /** React setter for {@link activeSession}. Stable identity. */
+  setActiveSession: React.Dispatch<React.SetStateAction<Session | null>>
+  /**
+   * Mirror ref of {@link activeSession} for async/debounced callers that
+   * cannot close over the latest value. Kept in sync on every render.
+   */
+  activeSessionRef: React.MutableRefObject<Session | null>
+
+  /** Chat + system timeline entries for the active session. */
+  messages: Message[]
+  /** React setter for {@link messages}. Stable identity. */
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>
+  /** Mirror ref of {@link messages}, written each render. */
+  messagesRef: React.MutableRefObject<Message[]>
+
+  /** Agent-authored tasks for the active session. */
+  tasks: AgentTask[]
+  /** React setter for {@link tasks}. Stable identity. */
+  setTasks: React.Dispatch<React.SetStateAction<AgentTask[]>>
+  /** Mirror ref of {@link tasks}, written each render. */
+  tasksRef: React.MutableRefObject<AgentTask[]>
+
+  /** Per-agent status bag (idle/reading/thinking/...) keyed by agent name. */
+  agentStates: Record<string, AgentState>
+  /** React setter for {@link agentStates}. Stable identity. */
+  setAgentStates: React.Dispatch<React.SetStateAction<Record<string, AgentState>>>
+}
+
+/**
+ * Owns the session-scoped state that used to live inline in App.tsx:
+ * `activeSession`, `messages`, `tasks`, `agentStates`. Each piece of state
+ * is paired with a `.current`-mirror ref so async callers (save debounce,
+ * orchestrator callbacks, keyboard shortcuts) can read the latest value
+ * without the stale-closure hazard.
+ *
+ * The hook is intentionally state-only — it does not own any side effects,
+ * hydration, or persistence. Those concerns live in {@link useSession} and
+ * {@link useOrchestratorWiring} (W0-T010), which consume this hook's setters
+ * and refs via their options.
+ *
+ * Splitting state from flows lets {@link useMarkupEditor} receive
+ * `activeSessionRef` and `setActiveSession` as plain options rather than
+ * through a mutable callback bag, eliminating the W0-T008 `callbacksRef`
+ * bridge.
+ */
+export function useSessionState(): UseSessionStateResult {
+  const [activeSession, setActiveSession] = useState<Session | null>(null)
+  const activeSessionRef = useRef<Session | null>(null)
+  useEffect(() => { activeSessionRef.current = activeSession })
+
+  const [messages, setMessages] = useState<Message[]>([])
+  const messagesRef = useRef<Message[]>(messages)
+  useEffect(() => { messagesRef.current = messages })
+
+  const [tasks, setTasks] = useState<AgentTask[]>([])
+  const tasksRef = useRef<AgentTask[]>(tasks)
+  useEffect(() => { tasksRef.current = tasks })
+
+  const [agentStates, setAgentStates] = useState<Record<string, AgentState>>({})
+
+  return {
+    activeSession,
+    setActiveSession,
+    activeSessionRef,
+    messages,
+    setMessages,
+    messagesRef,
+    tasks,
+    setTasks,
+    tasksRef,
+    agentStates,
+    setAgentStates,
+  }
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { listSessions, getSession, createSession, loadDocument, loadChatMessages, loadAgentPersonas, saveAgentPersonas, saveDocument, loadAgentTasks } from '../lib/session-store'
 import { DOC_TEMPLATES } from '../templates'
 import { supabase } from '../lib/supabase'
@@ -27,6 +27,12 @@ export { now, uid }
 
 interface UseSessionOptions {
   editor: Editor | null
+  /** Current session state, owned by `useSessionState`. */
+  activeSession: Session | null
+  /** Setter for the active session, owned by `useSessionState`. */
+  setActiveSession: React.Dispatch<React.SetStateAction<Session | null>>
+  /** Mirror ref of the active session, owned by `useSessionState`. */
+  activeSessionRef: React.MutableRefObject<Session | null>
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
   setTimeline: React.Dispatch<React.SetStateAction<import('../types').TimelineEntry[]>>
   setAgentStates: React.Dispatch<React.SetStateAction<Record<string, AgentState>>>
@@ -47,6 +53,9 @@ interface UseSessionOptions {
 
 export function useSession({
   editor,
+  activeSession,
+  setActiveSession,
+  activeSessionRef,
   setMessages,
   setTimeline,
   setAgentStates,
@@ -58,8 +67,6 @@ export function useSession({
   setTasks,
   suppressDocHydrateRef,
 }: UseSessionOptions) {
-  const [activeSession, setActiveSession] = useState<Session | null>(null)
-  const activeSessionRef = useRef<Session | null>(null)
   const [sessions, setSessions] = useState<Session[]>([])
   const [sessionsLoaded, setSessionsLoaded] = useState(false)
   const [activeAgents, setActiveAgents] = useState<AgentConfig[]>(DEFAULT_AGENT_CONFIGS)
@@ -245,7 +252,7 @@ export function useSession({
     setTimeline([])
     setSaveStatus('idle')
     history.pushState(null, '', '/')
-  }, [setMessages, setTimeline, setAgentStates, setSaveStatus])
+  }, [setActiveSession, activeSessionRef, setMessages, setTimeline, setAgentStates, setSaveStatus])
 
   // URL routing: load session from URL on mount + popstate handling
   useEffect(() => {
@@ -283,9 +290,6 @@ export function useSession({
   }, [activeSession?.title])
 
   return {
-    activeSession,
-    setActiveSession,
-    activeSessionRef,
     sessions,
     setSessions,
     sessionsLoaded,


### PR DESCRIPTION
## What
- Added `src/hooks/use-session-state.ts` owning `activeSession`, `messages`, `tasks`, `agentStates`, their setters, and their `.current` mirror refs.
- Removed the `callbacksRef` / `MarkupEditorCallbacks` bridge introduced in W0-T008; `useMarkupEditor` now receives `activeSessionRef` and `setActiveSession` directly.
- Switched `useSession` to consume session state via options rather than own it, so both hooks share a single source of truth from `useSessionState`.

## Why
`W0-T009` in `orchestration/queue.json`, per `orchestration/plan.md`: **"Split App.tsx: extract session state hook. `useSessionState()` owns activeSession, messages, tasks, agentStates."** This PR also lands the T008 follow-up Jasper approved: delete the temporary `callbacksRef` bridge now that `useSessionState` is called before `useMarkupEditor`, so refs are live when the editor mounts.

## Acceptance
- [x] `src/hooks/use-session-state.ts` exports the hook
- [x] App.tsx uses it; `callbacksRef` and `MarkupEditorCallbacks` are deleted
- [x] All existing tests still pass (166/166)
- [x] Build, lint, typecheck green
- [x] Dev server boots (HTTP 200 on `/`)

## Verification
- `npm run lint` — clean (0 errors, 0 warnings)
- `npm run typecheck` — clean
- `npm test` — 166/166 passing (10 test files)
- `npm run build` — built in 3.39s
- `npm run dev` — HTTP 200 at `http://localhost:5173/`

## Risk
Low. Behavior is identical: same debounce values, same save pipeline, same hydration order. Refs share the same mutable object between `useSessionState` and `useSession`, preserving the pre-existing synchronous `activeSessionRef.current = session` writes in `handleSessionSelect` / `resetToHome` / popstate handlers. `useMarkupEditor` now reads `activeSessionRef.current` directly at debounce-fire time — identical semantics to the previous `callbacksRef.current.getActiveSession()` indirection.

App.tsx LOC: 581 → 574 (-7 net; ~30 lines of state + bridge removed, replaced by one hook call).

## Task
`W0-T009` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
