### PR TITLE
fix: break vendor-tiptap <-> vendor-tambo circular chunk (prod hotfix)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -202,13 +202,24 @@ export default defineConfig(({ mode }) => {
       chunkSizeWarningLimit: 1500,
       rollupOptions: {
         output: {
+          // Tambo re-exports Tiptap types/runtime and vice-versa, creating a
+          // circular chunk graph when split across manual chunks. The prior
+          // config produced:
+          //   "Circular chunk: vendor-tiptap -> vendor-tambo -> vendor-tiptap"
+          // which at runtime surfaced as a TypeError when one chunk's module
+          // init ran against an uninitialized React namespace export from
+          // the other (e.g. "Cannot set properties of undefined (setting
+          // 'Activity')"). Merge the two chunks into one to eliminate the
+          // cycle. The combined chunk is still lazily requested on first use.
           manualChunks: {
-            'vendor-tiptap': ['@tiptap/react', '@tiptap/starter-kit', '@tiptap/extension-placeholder'],
+            'vendor-tiptap-tambo': [
+              '@tiptap/react', '@tiptap/starter-kit', '@tiptap/extension-placeholder',
+              '@tambo-ai/react', '@tambo-ai/react-ui-base', '@tambo-ai/typescript-sdk',
+            ],
             'vendor-supabase': ['@supabase/supabase-js'],
             'vendor-shaders': ['@paper-design/shaders-react'],
             'vendor-posthog': ['posthog-js'],
             'vendor-framer': ['framer-motion'],
-            'vendor-tambo': ['@tambo-ai/react', '@tambo-ai/react-ui-base', '@tambo-ai/typescript-sdk'],
             'vendor-radix': ['@radix-ui/react-dropdown-menu', '@radix-ui/react-popover', '@radix-ui/react-slot', 'radix-ui'],
             'vendor-markdown': ['streamdown', 'highlight.js', 'dompurify'],
           },


### PR DESCRIPTION
## What
Merges `vendor-tiptap` and `vendor-tambo` manual chunks into a single `vendor-tiptap-tambo` chunk in \`vite.config.ts\`.

## Why — live prod crash

Prod was crashing on first paint with:

\`\`\`
Uncaught TypeError: Cannot set properties of undefined (setting 'Activity')
  at DS (vendor-tambo-BladJgzp.js:2:5162)
  at US (vendor-tambo-BladJgzp.js:2:8272)
\`\`\`

Vite was emitting this warning on every build (visible in Vercel build logs):

> Circular chunk: vendor-tiptap -> vendor-tambo -> vendor-tiptap. Please adjust the manual chunk logic for these chunks.

When a chunk cycle exists, Rollup generates module wrappers that assume both sides are initialized before any re-exports are accessed. At runtime, one chunk's init code ran \`Oe.Activity = d\` (React 19.2 re-exporting \`Activity\` into its namespace object) while the other chunk's wrapper hadn't yet resolved \`Oe\` — crash.

The cycle is structural: \`@tambo-ai/react\` and \`@tiptap/react\` import each other transitively (via \`@tambo-ai/react-ui-base\`). As long as that's true, splitting them into separate chunks is unsafe. Merging them eliminates the cycle.

## Scope
- One file changed: \`vite.config.ts\`
- One chunk removed, one added (same six packages, single chunk now)
- No runtime code, no dep changes

## Verification
- \`npm run build\` — no more \"Circular chunk\" warning; single merged chunk produced (\`vendor-tiptap-tambo-*.js\`, ~1.2MB = roughly equal to old two-chunk total)
- \`npm run lint\` ✓
- \`npm run typecheck\` ✓
- \`npm test\` ✓ (166 passing)

## Risk
low — chunking change only, no semantic change. Bundle is slightly different in composition but the same packages are shipped.

## Rollback
If this causes a regression, revert and use \`manualChunks: undefined\` to let Vite auto-chunk.

## Follow-up
W0-Txxx — audit all \`manualChunks\` for other circular warnings; consider function-form manualChunks with dependency-graph awareness.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
