### PR TITLE
refactor: extract editor lock coordinator from orchestrator.ts (W0-T007)

### DIFF
--- a/src/__tests__/editor-lock.test.ts
+++ b/src/__tests__/editor-lock.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createEditorLockCoordinator } from '../orchestrator/editor-lock'
+
+describe('createEditorLockCoordinator', () => {
+  describe('lock state', () => {
+    it('starts unlocked with a null holder', () => {
+      const lock = createEditorLockCoordinator()
+      expect(lock.isLocked()).toBe(false)
+      expect(lock.lockHolder()).toBeNull()
+    })
+
+    it('reports locked when the ref carries an agent name', () => {
+      const ref = { current: null as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      ref.current = 'Aiden'
+      expect(lock.isLocked()).toBe(true)
+      expect(lock.lockHolder()).toBe('Aiden')
+    })
+
+    it('returns the same ref instance on every getRef() call', () => {
+      const ref = { current: null as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      expect(lock.getRef()).toBe(ref)
+      expect(lock.getRef()).toBe(lock.getRef())
+    })
+
+    it('allocates an internal ref when none is supplied', () => {
+      const lock = createEditorLockCoordinator()
+      const ref = lock.getRef()
+      expect(ref).toEqual({ current: null })
+      ref.current = 'Nova'
+      expect(lock.lockHolder()).toBe('Nova')
+    })
+  })
+
+  describe('waitForUnlock', () => {
+    it('resolves immediately when the lock is free', async () => {
+      const lock = createEditorLockCoordinator()
+      await expect(lock.waitForUnlock()).resolves.toBeUndefined()
+    })
+
+    it('defers resolution until the lock is released via runQueued', async () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const resolved = vi.fn()
+      const p = lock.waitForUnlock().then(resolved)
+
+      // Still locked — no resolution yet
+      await Promise.resolve()
+      expect(resolved).not.toHaveBeenCalled()
+
+      ref.current = null
+      lock.runQueued()
+      await p
+      expect(resolved).toHaveBeenCalledOnce()
+    })
+
+    it('resolves every concurrent waiter on a single release', async () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const a = lock.waitForUnlock()
+      const b = lock.waitForUnlock()
+      const c = lock.waitForUnlock()
+
+      ref.current = null
+      lock.runQueued()
+
+      await expect(Promise.all([a, b, c])).resolves.toEqual([undefined, undefined, undefined])
+    })
+  })
+
+  describe('enqueueWhenUnlocked', () => {
+    it('runs the action synchronously when the lock is free', () => {
+      const lock = createEditorLockCoordinator()
+      const action = vi.fn()
+      lock.enqueueWhenUnlocked(action)
+      expect(action).toHaveBeenCalledOnce()
+    })
+
+    it('holds the action while locked and fires it on runQueued', () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const action = vi.fn()
+      lock.enqueueWhenUnlocked(action)
+      expect(action).not.toHaveBeenCalled()
+
+      ref.current = null
+      lock.runQueued()
+      expect(action).toHaveBeenCalledOnce()
+    })
+
+    it('drains queued actions in FIFO order', () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const calls: string[] = []
+      lock.enqueueWhenUnlocked(() => calls.push('first'))
+      lock.enqueueWhenUnlocked(() => calls.push('second'))
+      lock.enqueueWhenUnlocked(() => calls.push('third'))
+
+      ref.current = null
+      lock.runQueued()
+      expect(calls).toEqual(['first', 'second', 'third'])
+    })
+
+    it('defers work enqueued from inside a callback to the next drain', () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const calls: string[] = []
+
+      lock.enqueueWhenUnlocked(() => {
+        calls.push('first')
+        // Re-acquire the lock mid-drain (simulating agent-actions holding it)
+        ref.current = 'Nova'
+        lock.enqueueWhenUnlocked(() => calls.push('nested'))
+      })
+
+      ref.current = null
+      lock.runQueued()
+      expect(calls).toEqual(['first'])
+
+      // Release the second lock and drain again
+      ref.current = null
+      lock.runQueued()
+      expect(calls).toEqual(['first', 'nested'])
+    })
+  })
+
+  describe('runQueued', () => {
+    it('is a no-op when nothing is queued', () => {
+      const lock = createEditorLockCoordinator()
+      expect(() => lock.runQueued()).not.toThrow()
+    })
+
+    it('resolves waiters and fires callbacks on the same release', async () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const events: string[] = []
+
+      const waited = lock.waitForUnlock().then(() => events.push('waiter'))
+      lock.enqueueWhenUnlocked(() => events.push('callback'))
+
+      ref.current = null
+      lock.runQueued()
+      await waited
+
+      expect(events).toContain('waiter')
+      expect(events).toContain('callback')
+      expect(events).toHaveLength(2)
+    })
+  })
+
+  describe('destroy', () => {
+    it('clears the ref', () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      lock.destroy()
+      expect(ref.current).toBeNull()
+      expect(lock.isLocked()).toBe(false)
+    })
+
+    it('drops pending callbacks so they never fire', () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const action = vi.fn()
+      lock.enqueueWhenUnlocked(action)
+
+      lock.destroy()
+      lock.runQueued()
+      expect(action).not.toHaveBeenCalled()
+    })
+
+    it('resolves any outstanding waiters so awaiters unblock', async () => {
+      const ref = { current: 'Aiden' as string | null }
+      const lock = createEditorLockCoordinator(ref)
+      const p = lock.waitForUnlock()
+      lock.destroy()
+      await expect(p).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -10,6 +10,7 @@ import { type PhaseState, initialPhaseState, phaseReducer, isActionAllowed } fro
 import { getAgentMode } from './agent-modes'
 import { detectObservations, resetWizard } from './wizard-of-oz'
 import { createTurnQueue, type TurnRequest } from './orchestrator/turn-queue'
+import { createEditorLockCoordinator } from './orchestrator/editor-lock'
 
 export type { AgentConfig }
 
@@ -95,7 +96,8 @@ function approvedPayloadToAction(agent: string, payload: EditProposalPayload): A
 export function createOrchestrator(config: OrchestratorConfig): OrchestratorHandle {
   const turnQueue = createTurnQueue({ agents: config.agents })
   let destroyed = false
-  const editorLockRef: { current: string | null } = { current: null }
+  const editorLock = createEditorLockCoordinator()
+  const editorLockRef = editorLock.getRef()
   const typingTimers: Record<string, number> = {}
   const pendingInstructions: Record<string, { trigger: AskParams['trigger'], instruction: string }> = {}
   let lastActionDescription: Record<string, string> = {}
@@ -217,7 +219,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           instruction: req.instruction,
           recentChange: lastActionDescription[otherAgent],
           otherAgentLastAction: lastActionDescription[otherAgent],
-          lockHolder: editorLockRef.current,
+          lockHolder: editorLock.lockHolder(),
           persona: agentCfg?.persona || '',
           otherAgents: agentNames,
           sessionTemplate: config.sessionTemplate,
@@ -652,7 +654,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
     resetHeartbeat()
     resetWizard()
     turnQueue.reset()
-    editorLockRef.current = null
+    editorLock.destroy()
     for (const name of agentNames) {
       consecutiveFailures[name] = 0
       delete pendingInstructions[name]

--- a/src/orchestrator/editor-lock.ts
+++ b/src/orchestrator/editor-lock.ts
@@ -1,0 +1,111 @@
+/**
+ * Editor lock coordinator.
+ *
+ * The Tiptap editor can only accept one writer at a time (insert/replace/image
+ * mutations walk the ProseMirror state in character-by-character passes). The
+ * orchestrator and `agent-actions.ts` share a single mutable ref —
+ * `{ current: string | null }` — that names the agent currently holding the
+ * editor. While locked, other agents must either wait or defer their work.
+ *
+ * This module encapsulates that ref plus a small hold/release surface:
+ *
+ * - `isLocked()` / `lockHolder()` — read-only checks used when building prompts
+ *   (so an agent knows whether a peer is mid-write).
+ * - `waitForUnlock()` — promise that resolves when the ref goes back to null.
+ * - `enqueueWhenUnlocked(action)` — queue a zero-arg callback to fire the next
+ *   time the lock is free, in FIFO order.
+ * - `runQueued()` — drain queued callbacks; safe to call when already unlocked.
+ * - `destroy()` — drop pending callbacks and clear the ref.
+ *
+ * The ref itself stays exposed via `getRef()` because `executeAgentAction` and
+ * `askAgent` still accept the raw object directly. Behavior is identical to
+ * the prior inline implementation; this module purely centralizes access.
+ *
+ * Factory pattern mirrors `createTurnQueue` / `createRateLimiter` — each
+ * orchestrator instance owns its own coordinator with closed-over state.
+ */
+
+export type EditorLockRef = { current: string | null }
+
+export interface EditorLockCoordinator {
+  /** The shared ref, passed to `executeAgentAction` and `askAgent`. */
+  getRef(): EditorLockRef
+  /** Current holder name, or null when the editor is free. */
+  lockHolder(): string | null
+  /** True when any agent currently holds the editor. */
+  isLocked(): boolean
+  /**
+   * Resolves the next time the lock is free. Resolves immediately when already
+   * unlocked. Multiple concurrent waiters all resolve on the same release.
+   */
+  waitForUnlock(): Promise<void>
+  /**
+   * Queue a zero-arg callback to run the next time the lock releases. When the
+   * lock is already free, the callback is invoked synchronously. Callbacks
+   * fire in FIFO order on `runQueued()`.
+   */
+  enqueueWhenUnlocked(action: () => void): void
+  /**
+   * Drain any queued callbacks. Safe to call while unlocked — intended to be
+   * invoked by the lock holder after release. No-op when the queue is empty.
+   */
+  runQueued(): void
+  /** Clear the ref, drop every pending callback/waiter. Used in destroy(). */
+  destroy(): void
+}
+
+/**
+ * Create a coordinator bound to an existing ref (when the orchestrator needs
+ * to share a ref it already allocated) or to a fresh internal ref when none
+ * is supplied. Passing the ref explicitly preserves reference identity for
+ * callers that capture it (e.g. `executeAgentAction`).
+ */
+export function createEditorLockCoordinator(
+  ref: EditorLockRef = { current: null },
+): EditorLockCoordinator {
+  const pending: Array<() => void> = []
+  const waiters: Array<() => void> = []
+
+  function drainWaiters() {
+    const toResolve = waiters.splice(0, waiters.length)
+    for (const resolve of toResolve) resolve()
+  }
+
+  return {
+    getRef() {
+      return ref
+    },
+    lockHolder() {
+      return ref.current
+    },
+    isLocked() {
+      return ref.current !== null
+    },
+    waitForUnlock() {
+      if (ref.current === null) return Promise.resolve()
+      return new Promise<void>((resolve) => {
+        waiters.push(resolve)
+      })
+    },
+    enqueueWhenUnlocked(action) {
+      if (ref.current === null) {
+        action()
+        return
+      }
+      pending.push(action)
+    },
+    runQueued() {
+      // Resolve any pending waiters first so awaiters observe the unlocked
+      // state before queued callbacks potentially re-acquire the lock.
+      drainWaiters()
+      // Snapshot so callbacks that enqueue new work run on the next drain.
+      const toRun = pending.splice(0, pending.length)
+      for (const action of toRun) action()
+    },
+    destroy() {
+      ref.current = null
+      pending.length = 0
+      drainWaiters()
+    },
+  }
+}


### PR DESCRIPTION
## What
- Add `src/orchestrator/editor-lock.ts` with `createEditorLockCoordinator()` factory (mirrors `createTurnQueue` / `createRateLimiter` pattern)
- Expose `getRef()`, `lockHolder()`, `isLocked()`, `waitForUnlock()`, `enqueueWhenUnlocked()`, `runQueued()`, `destroy()`
- Orchestrator composes the coordinator; `editorLockRef` identity preserved so `executeAgentAction` and `askAgent` keep working unchanged
- Add 16 unit tests in `src/__tests__/editor-lock.test.ts`

## Why
`orchestration/queue.json` task `W0-T007` — centralize the shared lock ref and give it a testable surface so later tasks (heartbeat/turn-queue follow-ups) can coordinate on unlock events without reaching into orchestrator internals.

## Acceptance
- [x] `src/orchestrator/editor-lock.ts` exports `createEditorLockCoordinator` and `EditorLockCoordinator` interface with factory pattern
- [x] Methods: `isLocked`, `waitForUnlock`, `enqueueWhenUnlocked`, `runQueued`, `destroy` (plus `getRef` / `lockHolder` for the shared-ref API)
- [x] Orchestrator composes the coordinator; public API unchanged
- [x] `src/__tests__/editor-lock.test.ts` — 16 tests covering locked/unlocked state, wait-then-run, enqueue FIFO ordering, destroy clears pending/waiters
- [x] All gates green

## Verification
- `npm run lint` — clean
- `npx tsc --noEmit -p tsconfig.app.json` — clean
- `npm test` — 182 passed (11 files); was 166 before (+16 new)
- `npm run build` — built in 4.34s

## Risk
Low. The coordinator still vends the same mutable `{ current }` ref that `agent-actions.ts` and `askAgent` hold onto, so the wait-for-lock loop in `executeAgentAction` is untouched. Only three callsites in `orchestrator.ts` were swapped (ref init, `lockHolder` read for prompt, destroy reset).

## Task
`W0-T007` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
