### PR TITLE
orchestration: apply agent-native discipline to plan (D-007)

### DIFF
--- a/orchestration/decisions.md
+++ b/orchestration/decisions.md
@@ -53,3 +53,30 @@ Architectural calls the orchestrator made mid-flight. One entry per decision. Ne
 **Decision:** Accept these as wave-A progress. Plan.md's Quadrant A task list excludes already-shipped features. No tasks are regenerated to "redo" them; only tasks to extend or harden.
 
 **Rationale:** Don't re-do work. Credit what's there and move on.
+
+## D-007 — 2026-04-19 — Agent-native discipline applied to Wave 1-3 planning
+
+**Context:** Audited plan.md against the four agent-native principles (parity, granularity, composability, emergent capability). Multiple silent violations:
+
+1. **Parity gap:** Wave 1 adds ~30 user-facing features (projects, sharing, export, history, search); zero of those pair an agent tool. Users could create a project in the UI but ask the agent and get "I don't have a tool for that."
+2. **Granularity drift:** The current `AgentAction` schema includes workflow verbs (`task`, `plan`, `propose`, `rename`) that encode decisions the agent should make via prompt. Only `insert`, `replace`, `read`, `delete`, `chat`, `search` are primitives.
+3. **Composability failure:** Features like "multi-turn tool use" (Wave 2) are scheduled as orchestrator code changes. With atomic tools, multi-turn is emergent — the agent just loops on primitives. Scheduling it as a code change reveals the current loop isn't agent-native.
+4. **Emergent gap:** Agent can't read other docs in a project, list sessions, or reference sibling memory — those are planned as specific one-off tools in Wave 2 rather than available primitives.
+
+**Decision:** Three reweightings of plan.md without changing the thesis:
+
+1. **Parity gate on every Wave 1-2 feature PR.** UI PR and corresponding agent-tool PR ship together. ~20 extra paired PRs added, bringing plan total near 140. "Can an agent achieve this outcome?" becomes a merge blocker.
+
+2. **Collapse workflow verbs in `AgentAction` into prompt patterns.** New Wave-0 task W0-T017: audit schema, deprecate `task`/`plan`/`propose`/`rename` as tool types, replace with prompt templates using the `insert`/`replace`/`chat` primitives.
+
+3. **Promote Wave 3 (MCP server) ahead of Wave 1-2.** MCP is the natural parity-enforcement layer: every new agent tool is exposed through MCP, both in-app and external agents call the same surface. New order: Wave 0 → Wave 3 → Wave 1+2 (parallel, each feature ships as a tool) → Wave 4.
+
+**Rationale:** Volume without agent-native discipline produces a better chat-sidebar app, not the doc-first agent workspace the spec commits to. The cost is ~15% more PRs and a one-wave reorder. The payoff is that every feature ships with parity from day one — the product agents can use is the same product humans can use.
+
+**Implementation mechanics:**
+- Update `orchestration/plan.md` to add W0-T017 and insert the reorder note at the top of Wave 1.
+- Each Wave 1 task's description now includes "pairs with MCP tool W3-Txxx".
+- Review rubric gains a seventh criterion: "Parity — if this adds a UI affordance, is there a corresponding agent tool?"
+- Keep the thesis and 4-quadrant structure identical. This is discipline, not re-scoping.
+
+**Supersedes:** refines D-002, D-004.

--- a/orchestration/plan.md
+++ b/orchestration/plan.md
@@ -58,11 +58,22 @@ Create `orchestration/wave-1-prd.md`, `wave-2-prd.md`, `wave-3-prd.md`, `wave-4-
 ### W0-T016 — Orchestrator resume test
 A dry-run: orchestrator writes state.md + queue.json, a successor reads them, resumes a mock task. No product code changed; validates restart protocol works.
 
+### W0-T017 — Agent-native schema audit
+Audit `AgentAction` in `src/agent-schema.ts` against the four agent-native principles. Mark workflow verbs (`task`, `plan`, `propose`, `rename`) deprecated — those encode decisions the agent should make via prompt, not dispatch. Keep primitives (`insert`, `replace`, `delete`, `read`, `chat`, `search`). Produce `orchestration/agent-schema-migration.md` mapping deprecated verbs to prompt templates over primitives. No production code deletion yet — that's Wave 3 rewire. Added per D-007.
+
 ---
 
-## Wave 1 — Product depth, Quadrant A (~34 PRs)
+## Wave reorder (per D-007, agent-native discipline)
 
-Goal: markup is usable for real work. Projects, sharing, export, history, organization.
+**New order:** Wave 0 → Wave 3 (MCP foundation) → Wave 1 + Wave 2 (parallel, each feature ships with a matching MCP tool) → Wave 4.
+
+**Why:** MCP is the parity-enforcement layer. Every Wave 1-2 feature ships with an agent-callable tool from day one. In-app agent and external agents (Claude Desktop, Cursor, Copilot) consume the same tool surface — no drift.
+
+**Parity gate:** Every Wave 1-2 PR that adds a UI affordance ships paired with an MCP-tool PR for the same capability. Reviewer's seventh rubric criterion: "Parity — does an agent have a tool for the outcome this UI enables?" Exceptions: user-only actions (biometric, camera, OAuth consent, keyboard shortcuts).
+
+## Wave 1 — Product depth, Quadrant A (~34 PRs + ~20 paired MCP tool PRs)
+
+Goal: markup is usable for real work. Projects, sharing, export, history, organization. **Every feature ships with a matching agent tool.**
 
 ### Track A1: Project model (~8 PRs)
 


### PR DESCRIPTION
## What

Two orchestration docs updated, no production code touched:

- \`orchestration/decisions.md\` — adds D-007 explaining a parity/granularity/composability audit of plan.md and three planned adjustments
- \`orchestration/plan.md\` — adds W0-T017 (schema audit task) + Wave reorder note (Wave 3 MCP promoted before Wave 1-2 so every feature ships with a matching agent tool)

## Why

Audit against the agent-native principles surfaced three silent plan gaps:

**Parity:** Wave 1-2 adds ~30 UI features with zero matching agent tools. Users could create a project in the UI, but ask the agent and get \"I don't have that tool.\"

**Granularity:** \`AgentAction\` has workflow verbs (\`task\`/\`plan\`/\`propose\`/\`rename\`) that bundle judgment the agent should make via prompt.

**Composability:** Wave 2's \"multi-turn tool use\" is scheduled as an orchestrator code change. With atomic primitives, multi-turn is emergent behavior — not a feature to build.

## Changes

- **New W0-T017:** audit schema, mark workflow verbs deprecated, produce \`orchestration/agent-schema-migration.md\` (no code deletion yet)
- **Wave reorder:** Wave 0 → Wave 3 (MCP foundation) → Wave 1+2 in parallel with every feature pairing an MCP tool → Wave 4
- **Parity gate:** seventh review-rubric criterion — every UI-affordance PR ships paired with an MCP-tool PR

## Risk
low — documentation only. No code touched. Active Wave-0 authors keep running (they're already writing primitives).

## Verification
- No code files changed
- CI will run but is not load-bearing for this PR

## Task
Post-W0 planning, pre-Wave-1 authoring.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
