### PR TITLE
refactor: extract reaction router from orchestrator.ts (W0-T006)

### DIFF
--- a/src/__tests__/reaction-router.test.ts
+++ b/src/__tests__/reaction-router.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { createReactionRouter } from '../orchestrator/reaction-router'
+
+const agents = [
+  { name: 'Aiden' },
+  { name: 'Nova' },
+  { name: 'Lex' },
+]
+
+describe('createReactionRouter', () => {
+  describe('pendingReaction', () => {
+    it('defaults to null and toggles via set/clear', () => {
+      const r = createReactionRouter({ agents })
+      expect(r.getPending()).toBeNull()
+      r.setPending('Aiden')
+      expect(r.getPending()).toBe('Aiden')
+      r.clearPending()
+      expect(r.getPending()).toBeNull()
+    })
+
+    it('isPending reflects whether an agent currently holds the slot', () => {
+      const r = createReactionRouter({ agents })
+      expect(r.isPending('Aiden')).toBe(false)
+      r.setPending('Aiden')
+      expect(r.isPending('Aiden')).toBe(true)
+      expect(r.isPending('Nova')).toBe(false)
+    })
+
+    it('clearPendingIf only clears when the agent matches', () => {
+      const r = createReactionRouter({ agents })
+      r.setPending('Aiden')
+      r.clearPendingIf('Nova')
+      expect(r.getPending()).toBe('Aiden')
+      r.clearPendingIf('Aiden')
+      expect(r.getPending()).toBeNull()
+    })
+
+    it('clearPendingIf is a no-op when no agent is pending', () => {
+      const r = createReactionRouter({ agents })
+      r.clearPendingIf('Aiden')
+      expect(r.getPending()).toBeNull()
+    })
+
+    it('setPending overwrites the previous pending agent', () => {
+      const r = createReactionRouter({ agents })
+      r.setPending('Aiden')
+      r.setPending('Nova')
+      expect(r.getPending()).toBe('Nova')
+      expect(r.isPending('Aiden')).toBe(false)
+    })
+  })
+
+  describe('round-robin selection', () => {
+    it('rotates through candidates in order', () => {
+      const r = createReactionRouter({ agents })
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Nova')
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Lex')
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Nova')
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Lex')
+    })
+
+    it('wraps around when the index exceeds candidate length', () => {
+      const r = createReactionRouter({ agents })
+      for (let i = 0; i < 5; i++) r.pickNextReactor(['Nova', 'Lex'])
+      expect(r.getRoundRobinIndex()).toBe(5)
+      // Index 5 % 2 === 1 -> 'Lex'
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Lex')
+    })
+
+    it('returns null for an empty candidate list and does not advance the index', () => {
+      const r = createReactionRouter({ agents })
+      expect(r.pickNextReactor([])).toBeNull()
+      expect(r.getRoundRobinIndex()).toBe(0)
+      // Subsequent non-empty call starts at index 0
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Nova')
+    })
+
+    it('advances the shared index regardless of candidate-list size', () => {
+      const r = createReactionRouter({ agents })
+      r.pickNextReactor(['Nova']) // idx 0 -> 'Nova', index becomes 1
+      r.pickNextReactor(['Nova', 'Lex']) // idx 1 % 2 -> 'Lex', index becomes 2
+      expect(r.pickNextReactor(['Nova', 'Lex', 'Mira'])).toBe('Mira') // idx 2 % 3 -> 'Mira'
+      expect(r.getRoundRobinIndex()).toBe(3)
+    })
+
+    it('handles a single-candidate list (always returns that candidate)', () => {
+      const r = createReactionRouter({ agents })
+      expect(r.pickNextReactor(['Nova'])).toBe('Nova')
+      expect(r.pickNextReactor(['Nova'])).toBe('Nova')
+      expect(r.pickNextReactor(['Nova'])).toBe('Nova')
+      expect(r.getRoundRobinIndex()).toBe(3)
+    })
+  })
+
+  describe('reset', () => {
+    it('clears the pending agent and zeroes the round-robin index', () => {
+      const r = createReactionRouter({ agents })
+      r.setPending('Aiden')
+      r.pickNextReactor(['Nova', 'Lex'])
+      r.pickNextReactor(['Nova', 'Lex'])
+      expect(r.getPending()).toBe('Aiden')
+      expect(r.getRoundRobinIndex()).toBe(2)
+
+      r.reset()
+      expect(r.getPending()).toBeNull()
+      expect(r.getRoundRobinIndex()).toBe(0)
+      // Next pick starts at index 0 again
+      expect(r.pickNextReactor(['Nova', 'Lex'])).toBe('Nova')
+    })
+  })
+
+  describe('instance isolation', () => {
+    it('separate routers do not share state', () => {
+      const a = createReactionRouter({ agents })
+      const b = createReactionRouter({ agents })
+      a.setPending('Aiden')
+      a.pickNextReactor(['Nova', 'Lex'])
+      expect(b.getPending()).toBeNull()
+      expect(b.getRoundRobinIndex()).toBe(0)
+    })
+  })
+})

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -9,6 +9,7 @@ import { DEFAULT_LIMITS, DEFAULT_EXPERIMENTS, type OrchestratorLimits, type Agen
 import { type PhaseState, initialPhaseState, phaseReducer, isActionAllowed } from './phase-machine'
 import { getAgentMode } from './agent-modes'
 import { detectObservations, resetWizard } from './wizard-of-oz'
+import { createReactionRouter } from './orchestrator/reaction-router'
 
 export type { AgentConfig }
 
@@ -137,10 +138,8 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
   const turnCount: Record<string, number> = Object.fromEntries(config.agents.map(a => [a.name, 0]))
   // Track back-and-forth exchanges
   let exchangeCount = 0
-  // Track pending doc-edit reaction to prevent double-triggers
-  let pendingReaction: AgentName | null = null
-  // Round-robin index for balanced agent selection
-  let reactionRoundRobin = 0
+  // Reaction routing: who's pending + round-robin index for balanced selection
+  const reactionRouter = createReactionRouter({ agents: config.agents })
   // Track consecutive failures per agent
   const consecutiveFailures: Record<string, number> = Object.fromEntries(config.agents.map(a => [a.name, 0]))
   const pausedAgents = new Set<AgentName>()
@@ -288,7 +287,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         const actionDesc = describeAction(req.agent, action)
         lastActionDescription[req.agent] = actionDesc
         turnCount[req.agent]++
-        if (pendingReaction === req.agent) pendingReaction = null
+        reactionRouter.clearPendingIf(req.agent)
         processing = false
         const pending = pendingInstructions[req.agent]
         if (pending) {
@@ -316,7 +315,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         config.onAgentState(req.agent, 'idle')
         consecutiveFailures[req.agent] = 0
         turnCount[req.agent]++
-        if (pendingReaction === req.agent) pendingReaction = null
+        reactionRouter.clearPendingIf(req.agent)
         processing = false
         processQueue()
         return
@@ -353,7 +352,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           if (didDocEdit) {
             config.onDocAction?.(req.agent, actionDesc)
           }
-          if (pendingReaction === req.agent) pendingReaction = null
+          reactionRouter.clearPendingIf(req.agent)
           processing = false
 
           // Process queued instruction — but skip if it's the same one we just ran
@@ -371,13 +370,12 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           if (didEdit && queue.length === 0) {
             // Round-robin routing: rotate through other agents for balanced participation
             const otherNames = agentNames.filter(n => n !== req.agent)
-            const other: AgentName = otherNames[reactionRoundRobin % otherNames.length] || agentNames[0]
-            reactionRoundRobin++
+            const other: AgentName = reactionRouter.pickNextReactor(otherNames) ?? agentNames[0]
             // Initial (welcome/doc-opened) reactions don't count toward the exchange limit
             const countsAsExchange = !req.isInitial
-            if (other !== req.agent && (countsAsExchange ? exchangeCount < limits.maxExchanges : true) && turnCount[other] < limits.maxTurns && pendingReaction !== other) {
+            if (other !== req.agent && (countsAsExchange ? exchangeCount < limits.maxExchanges : true) && turnCount[other] < limits.maxTurns && !reactionRouter.isPending(other)) {
               if (countsAsExchange) exchangeCount++
-              pendingReaction = other
+              reactionRouter.setPending(other)
               const otherCfg = getAgentConfig(other)
               const reactionInstruction = buildReactionInstruction(req.agent, actionDesc, action.type, otherCfg?.persona || '')
               scheduleTimeout(() => {
@@ -458,7 +456,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
           turnCount[name] = 0
         }
         exchangeCount = 0
-        pendingReaction = null
+        reactionRouter.clearPending()
 
         // Classify doc state and decide session phase
         const docText = config.getDocText()
@@ -530,7 +528,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         scheduledTimers.forEach(id => clearTimeout(id))
         scheduledTimers.clear()
         exchangeCount = 0
-        pendingReaction = null
+        reactionRouter.clearPending()
         // Unpause agents on user interaction so they can retry
         pausedAgents.clear()
         for (const name of agentNames) consecutiveFailures[name] = 0
@@ -550,7 +548,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
       case 'agent-tagged': {
         const target = payload?.agent
         const from = payload?.from || 'someone'
-        if (target && pendingReaction === target) {
+        if (target && reactionRouter.isPending(target)) {
           log('agent-tagged skipped — already has pending reaction', target)
           break
         }
@@ -679,8 +677,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
     }
     lastActionDescription = {}
     exchangeCount = 0
-    pendingReaction = null
-    reactionRoundRobin = 0
+    reactionRouter.reset()
     pausedAgents.clear()
     phaseState = { ...initialPhaseState }
     currentDocState = 'blank'

--- a/src/orchestrator/reaction-router.ts
+++ b/src/orchestrator/reaction-router.ts
@@ -1,0 +1,90 @@
+type AgentName = string
+
+export interface ReactionRouterOptions {
+  /** Initial agent roster (only used as a tie-breaker fallback when round-robin yields no candidate). */
+  agents: ReadonlyArray<{ name: AgentName }>
+}
+
+/**
+ * Public interface of the reaction router. The orchestrator composes this to
+ * track which agent (if any) has a pending doc-edit reaction queued, and to
+ * rotate round-robin through other agents for balanced participation after a
+ * successful edit.
+ *
+ * The router owns only routing-order state (pendingReaction + roundRobin
+ * index). Eligibility policy (exchange limits, turn limits, pause state)
+ * remains in the orchestrator — this module purely answers "whose turn is it
+ * to react next?" and "is someone already queued to react?".
+ */
+export interface ReactionRouter {
+  /** The agent currently queued to react (or null). */
+  getPending(): AgentName | null
+  /** True when the given agent is currently the pending reactor. */
+  isPending(agent: AgentName): boolean
+  /** Mark an agent as the pending reactor. */
+  setPending(agent: AgentName): void
+  /** Clear the pending reactor slot. */
+  clearPending(): void
+  /**
+   * If the pending reactor matches the given agent, clear it. Used when a
+   * turn completes to release the slot only if it belonged to that agent.
+   */
+  clearPendingIf(agent: AgentName): void
+
+  /**
+   * Pick the next agent to react, rotating round-robin through `candidates`.
+   * Returns `null` when the candidate list is empty (orchestrator should fall
+   * back to its own defaulting). Advances the round-robin index on every call.
+   */
+  pickNextReactor(candidates: ReadonlyArray<AgentName>): AgentName | null
+
+  /** Current round-robin index (exposed for testing and introspection). */
+  getRoundRobinIndex(): number
+
+  /** Reset every piece of state: clears pending and zeroes the round-robin index. */
+  reset(): void
+}
+
+/**
+ * Factory mirroring the `createRateLimiter` / `createTurnQueue` pattern:
+ * returns a typed interface backed by closed-over state. No globals — each
+ * orchestrator instance owns its own router.
+ */
+export function createReactionRouter(_options: ReactionRouterOptions): ReactionRouter {
+  let pendingReaction: AgentName | null = null
+  let roundRobin = 0
+
+  return {
+    getPending() {
+      return pendingReaction
+    },
+    isPending(agent) {
+      return pendingReaction === agent
+    },
+    setPending(agent) {
+      pendingReaction = agent
+    },
+    clearPending() {
+      pendingReaction = null
+    },
+    clearPendingIf(agent) {
+      if (pendingReaction === agent) pendingReaction = null
+    },
+
+    pickNextReactor(candidates) {
+      if (candidates.length === 0) return null
+      const next = candidates[roundRobin % candidates.length]
+      roundRobin++
+      return next
+    },
+
+    getRoundRobinIndex() {
+      return roundRobin
+    },
+
+    reset() {
+      pendingReaction = null
+      roundRobin = 0
+    },
+  }
+}


### PR DESCRIPTION
## What
- New `src/orchestrator/reaction-router.ts` exporting `createReactionRouter(options)` factory + typed `ReactionRouter` interface.
- `src/orchestrator.ts` now composes the router for the `pendingReaction` slot and round-robin selection. Public API and external behavior unchanged.
- New `src/__tests__/reaction-router.test.ts` with 12 tests covering pendingReaction set/clear/isPending/clearPendingIf, round-robin order, index wraparound, empty-candidate null return, shared-index behavior across different candidate sizes, reset, and instance isolation.

## Why
Task `W0-T006` — continue the orchestrator decomposition by isolating reaction routing. Sibling of turn-queue (W0-T002, PR #227) and rate-limiter (W0-T004): same factory pattern, same state-ownership split — router owns only routing-order state (`pendingReaction` + round-robin index); eligibility policy (exchange limits, turn limits, pause) stays in the orchestrator.

## Acceptance
- [x] `src/orchestrator/reaction-router.ts` exports factory + typed interface
- [x] `src/orchestrator.ts` imports and uses it; behavior unchanged
- [x] New test file covers round-robin order, pendingReaction enqueue/dequeue, index wraparound, reset
- [x] lint + typecheck + test + build all green
- [x] No other files modified beyond orchestrator.ts + new files

## Verification
Locally on the worktree branch:
- `npm run lint` — passes (no warnings)
- `npx tsc -b --noEmit` — passes
- `npm test` — 178/178 passing across 11 files (was 166/166 across 10 files; +12 tests from `reaction-router.test.ts`)
- `npm run build` — passes (Vite build 4.22s)
- `orchestrator.test.ts` — 31/31 still passing (no regression in existing suite)
- `orchestrator.ts` LOC: 690 -> 687 (-3 lines net; -16 removed / +13 added in the refactor body)

## Risk
**Low.** Pure state-ownership refactor. The extracted module only encapsulates the `pendingReaction` slot and round-robin index + helpers — all policy (when to route, exchange/turn guards, reaction-delay scheduling, `buildReactionInstruction`) stays in `orchestrator.ts` and reads/writes through the same semantic operations. Full orchestrator test suite (reaction routing, agent-tagged short-circuit, doc-opened reset, user-message reset, destroy) passes unchanged.

## Task
`W0-T006` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
