### PR TITLE
refactor: extract heartbeat scheduler from orchestrator.ts (W0-T003)

### DIFF
--- a/src/__tests__/heartbeat-scheduler.test.ts
+++ b/src/__tests__/heartbeat-scheduler.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Stub window.setTimeout / clearTimeout so timers are deterministic.
+const timers: { id: number, fn: () => void, ms: number }[] = []
+let nextTimerId = 1
+
+vi.stubGlobal('window', {
+  setTimeout: (fn: () => void, ms: number) => {
+    const id = nextTimerId++
+    timers.push({ id, fn, ms })
+    return id
+  },
+  clearTimeout: (id: number) => {
+    const idx = timers.findIndex(t => t.id === id)
+    if (idx >= 0) timers.splice(idx, 1)
+  },
+})
+
+// Also stub the global clearTimeout that the scheduler uses in clearAll().
+vi.stubGlobal('clearTimeout', (id: number) => {
+  const idx = timers.findIndex(t => t.id === id)
+  if (idx >= 0) timers.splice(idx, 1)
+})
+
+import { createHeartbeatScheduler } from '../orchestrator/heartbeat-scheduler'
+
+function makeScheduler(overrides: Partial<Parameters<typeof createHeartbeatScheduler>[0]> = {}) {
+  return createHeartbeatScheduler({
+    heartbeatDelayMs: [20000, 30000],
+    fire: vi.fn(),
+    ...overrides,
+  })
+}
+
+function fireTimer(id: number) {
+  const timer = timers.find(t => t.id === id)
+  if (!timer) throw new Error(`Timer ${id} not found`)
+  // Remove from list (mimic browser behavior when a scheduled fn runs)
+  timers.splice(timers.indexOf(timer), 1)
+  timer.fn()
+}
+
+describe('createHeartbeatScheduler', () => {
+  beforeEach(() => {
+    timers.length = 0
+    nextTimerId = 1
+    vi.clearAllMocks()
+  })
+
+  describe('schedule', () => {
+    it('registers a timer with the requested delay and returns its id', () => {
+      const s = makeScheduler()
+      const cb = vi.fn()
+      const id = s.schedule(cb, 500)
+      expect(id).toBeGreaterThan(0)
+      expect(timers).toHaveLength(1)
+      expect(timers[0].ms).toBe(500)
+    })
+
+    it('runs the callback when the timer fires', () => {
+      const s = makeScheduler()
+      const cb = vi.fn()
+      const id = s.schedule(cb, 100)
+      expect(cb).not.toHaveBeenCalled()
+      fireTimer(id)
+      expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it('tracks multiple concurrent timers independently', () => {
+      const s = makeScheduler()
+      const cb1 = vi.fn()
+      const cb2 = vi.fn()
+      const cb3 = vi.fn()
+      s.schedule(cb1, 100)
+      s.schedule(cb2, 200)
+      s.schedule(cb3, 300)
+      expect(timers).toHaveLength(3)
+    })
+
+    it('guards callbacks so they do not run after destroy(), even if the timer still fires', () => {
+      const s = makeScheduler()
+      const cb = vi.fn()
+      // Grab the wrapper function the scheduler hands to setTimeout before destroy clears it.
+      s.schedule(cb, 100)
+      const wrapper = timers[0].fn
+      s.destroy()
+      // Simulate a stray/late timer invocation after destroy — the internal `destroyed`
+      // flag in the wrapper must short-circuit the user callback.
+      wrapper()
+      expect(cb).not.toHaveBeenCalled()
+    })
+
+    it('returns 0 and does not schedule after destroy()', () => {
+      const s = makeScheduler()
+      s.destroy()
+      const cb = vi.fn()
+      const id = s.schedule(cb, 100)
+      expect(id).toBe(0)
+      expect(timers).toHaveLength(0)
+    })
+
+    it('removes the timer id from tracking after it fires naturally', () => {
+      const s = makeScheduler()
+      const id = s.schedule(() => undefined, 100)
+      expect(timers).toHaveLength(1)
+      fireTimer(id)
+      // After firing, the internal Set should have dropped this id — clearAll() must
+      // not try to clear it again. Clearing all should succeed without error.
+      s.clearAll()
+      expect(timers).toHaveLength(0)
+    })
+  })
+
+  describe('clearAll', () => {
+    it('cancels every pending scheduled timer', () => {
+      const s = makeScheduler()
+      const cb1 = vi.fn()
+      const cb2 = vi.fn()
+      s.schedule(cb1, 100)
+      s.schedule(cb2, 200)
+      s.clearAll()
+      expect(timers).toHaveLength(0)
+      expect(cb1).not.toHaveBeenCalled()
+      expect(cb2).not.toHaveBeenCalled()
+    })
+
+    it('is idempotent on an empty scheduler', () => {
+      const s = makeScheduler()
+      s.clearAll()
+      s.clearAll()
+      expect(timers).toHaveLength(0)
+    })
+
+    it('also cancels the heartbeat timer', () => {
+      const fire = vi.fn()
+      const s = makeScheduler({ fire })
+      s.startHeartbeat()
+      expect(timers).toHaveLength(1)
+      s.clearAll()
+      expect(timers).toHaveLength(0)
+      expect(fire).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('heartbeat lifecycle', () => {
+    it('startHeartbeat schedules a timer within the configured min-max range', () => {
+      const s = makeScheduler({ heartbeatDelayMs: [20000, 30000] })
+      s.startHeartbeat()
+      expect(timers).toHaveLength(1)
+      expect(timers[0].ms).toBeGreaterThanOrEqual(20000)
+      expect(timers[0].ms).toBeLessThanOrEqual(30000)
+    })
+
+    it('uses the demo-mode 8-12s range when demoMode=true', () => {
+      const s = makeScheduler({ heartbeatDelayMs: [20000, 30000], demoMode: true })
+      s.startHeartbeat()
+      expect(timers).toHaveLength(1)
+      expect(timers[0].ms).toBeGreaterThanOrEqual(8000)
+      expect(timers[0].ms).toBeLessThanOrEqual(12000)
+    })
+
+    it('calls the fire callback when the heartbeat timer elapses', () => {
+      const fire = vi.fn()
+      const s = makeScheduler({ fire })
+      s.startHeartbeat()
+      const id = timers[0].id
+      fireTimer(id)
+      expect(fire).toHaveBeenCalledTimes(1)
+    })
+
+    it('startHeartbeat cancels any existing heartbeat before scheduling a new one', () => {
+      const s = makeScheduler()
+      s.startHeartbeat()
+      expect(timers).toHaveLength(1)
+      const firstId = timers[0].id
+      s.startHeartbeat()
+      // The old one should be cancelled; only the new one remains.
+      expect(timers).toHaveLength(1)
+      expect(timers.some(t => t.id === firstId)).toBe(false)
+    })
+
+    it('stopHeartbeat cancels the pending heartbeat', () => {
+      const s = makeScheduler()
+      s.startHeartbeat()
+      expect(timers).toHaveLength(1)
+      s.stopHeartbeat()
+      expect(timers).toHaveLength(0)
+    })
+
+    it('stopHeartbeat is a no-op when no heartbeat is scheduled', () => {
+      const s = makeScheduler()
+      s.stopHeartbeat()
+      expect(timers).toHaveLength(0)
+    })
+
+    it('startHeartbeat is a no-op after destroy()', () => {
+      const s = makeScheduler()
+      s.destroy()
+      s.startHeartbeat()
+      expect(timers).toHaveLength(0)
+    })
+  })
+
+  describe('destroy', () => {
+    it('clears every tracked timer', () => {
+      const s = makeScheduler()
+      s.schedule(() => undefined, 100)
+      s.schedule(() => undefined, 200)
+      s.startHeartbeat()
+      expect(timers).toHaveLength(3)
+      s.destroy()
+      expect(timers).toHaveLength(0)
+    })
+
+    it('prevents further scheduling after it runs', () => {
+      const s = makeScheduler()
+      s.destroy()
+      s.schedule(() => undefined, 100)
+      s.startHeartbeat()
+      expect(timers).toHaveLength(0)
+    })
+
+    it('is safe to call twice', () => {
+      const s = makeScheduler()
+      s.schedule(() => undefined, 100)
+      s.destroy()
+      s.destroy()
+      expect(timers).toHaveLength(0)
+    })
+  })
+
+  describe('instance isolation', () => {
+    it('two schedulers share no timer state', () => {
+      const a = makeScheduler()
+      const b = makeScheduler()
+      a.schedule(() => undefined, 100)
+      expect(timers).toHaveLength(1)
+      b.clearAll()
+      // b's clearAll should NOT cancel a's timer.
+      expect(timers).toHaveLength(1)
+      a.destroy()
+      expect(timers).toHaveLength(0)
+    })
+  })
+})

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -12,6 +12,7 @@ import { detectObservations, resetWizard } from './wizard-of-oz'
 import { createReactionRouter } from './orchestrator/reaction-router'
 import { createTurnQueue, type TurnRequest } from './orchestrator/turn-queue'
 import { createEditorLockCoordinator } from './orchestrator/editor-lock'
+import { createHeartbeatScheduler } from './orchestrator/heartbeat-scheduler'
 
 export type { AgentConfig }
 
@@ -131,10 +132,13 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
   // Track consecutive failures per agent
   const consecutiveFailures: Record<string, number> = Object.fromEntries(config.agents.map(a => [a.name, 0]))
   const pausedAgents = new Set<AgentName>()
-  // Track ALL scheduled timeouts so we can clear them on destroy/user-message
-  const scheduledTimers = new Set<number>()
-  // Heartbeat timer for proactive agent behaviors
-  let heartbeatTimer: number | null = null
+  // Scheduler owns all timer tracking + heartbeat lifecycle. See
+  // src/orchestrator/heartbeat-scheduler.ts.
+  const scheduler = createHeartbeatScheduler({
+    heartbeatDelayMs: limits.heartbeatDelayMs,
+    demoMode: config.demoMode,
+    fire: () => fireHeartbeat(),
+  })
   // Session phase managed by phase-machine reducer
   let phaseState: PhaseState = { ...initialPhaseState }
   // Doc state classification cached on doc-opened
@@ -183,22 +187,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
   // -----------------------------------------------------------------------
 
   function scheduleTimeout(fn: () => void, ms: number): number {
-    const id = window.setTimeout(() => {
-      scheduledTimers.delete(id)
-      if (!destroyed) fn()
-    }, ms)
-    scheduledTimers.add(id)
-    return id
-  }
-
-  function clearAllTimers() {
-    scheduledTimers.forEach(id => clearTimeout(id))
-    scheduledTimers.clear()
-    Object.keys(typingTimers).forEach(k => {
-      clearTimeout(typingTimers[k])
-      delete typingTimers[k]
-    })
-    stopHeartbeat()
+    return scheduler.schedule(fn, ms)
   }
 
   function enqueue(req: TurnRequest) {
@@ -524,9 +513,8 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
         // User messages take priority — clear everything
         turnQueue.clear()
         for (const name of agentNames) delete pendingInstructions[name]
-        // Cancel all pending reaction timeouts
-        scheduledTimers.forEach(id => clearTimeout(id))
-        scheduledTimers.clear()
+        // Cancel all pending reaction timeouts (incl. heartbeat — startHeartbeat is re-issued below)
+        scheduler.clearAll()
         turnQueue.resetExchangeCount()
         reactionRouter.clearPending()
         // Unpause agents on user interaction so they can retry
@@ -582,21 +570,7 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
   }
 
   function startHeartbeat() {
-    stopHeartbeat()
-    const [hbMin, hbMax] = limits.heartbeatDelayMs
-    const delay = config.demoMode ? 8000 + Math.random() * 4000 : hbMin + Math.random() * (hbMax - hbMin)
-    heartbeatTimer = scheduleTimeout(() => {
-      heartbeatTimer = null
-      fireHeartbeat()
-    }, delay)
-  }
-
-  function stopHeartbeat() {
-    if (heartbeatTimer) {
-      clearTimeout(heartbeatTimer)
-      scheduledTimers.delete(heartbeatTimer)
-      heartbeatTimer = null
-    }
+    scheduler.startHeartbeat()
   }
 
   async function fireHeartbeat() {
@@ -663,7 +637,11 @@ export function createOrchestrator(config: OrchestratorConfig): OrchestratorHand
 
   function destroy() {
     destroyed = true
-    clearAllTimers()
+    scheduler.destroy()
+    Object.keys(typingTimers).forEach(k => {
+      clearTimeout(typingTimers[k])
+      delete typingTimers[k]
+    })
     resetRateLimiter()
     resetHeartbeat()
     resetWizard()

--- a/src/orchestrator/heartbeat-scheduler.ts
+++ b/src/orchestrator/heartbeat-scheduler.ts
@@ -1,0 +1,93 @@
+/**
+ * Heartbeat scheduler — owns timer scheduling, tracking, and the heartbeat
+ * lifecycle for the orchestrator.
+ *
+ * Responsibilities:
+ *  - wrap `window.setTimeout` so every scheduled callback is tracked and can be
+ *    cancelled en masse on destroy / user-message / pause
+ *  - schedule a repeating heartbeat timer with a randomized min-max delay
+ *  - call an injected `fire` callback when the heartbeat elapses; the caller
+ *    is responsible for heartbeat business logic (observation generation,
+ *    reading orchestrator state, deciding what to do next) and for calling
+ *    `startHeartbeat()` again to reschedule
+ *
+ * Mirrors the factory pattern established by `createTurnQueue`
+ * (src/orchestrator/turn-queue.ts) and `createRateLimiter` (planned).
+ */
+
+export interface HeartbeatSchedulerOptions {
+  /** Min/max delay (inclusive) for the random heartbeat interval, in ms. */
+  heartbeatDelayMs: [number, number]
+  /** When true, use the shorter demo-mode heartbeat range (8-12s). */
+  demoMode?: boolean
+  /** Callback invoked when the heartbeat timer fires. */
+  fire: () => void | Promise<void>
+}
+
+export interface HeartbeatScheduler {
+  /**
+   * Schedule a callback to run after `delayMs`. Returns the timer id.
+   * Callbacks do not fire if `destroy()` has been called before they elapse.
+   * The timer is automatically untracked when it fires.
+   */
+  schedule(cb: () => void, delayMs: number): number
+  /** Cancel every tracked timer (including the heartbeat, if any). */
+  clearAll(): void
+  /** Schedule the next heartbeat. Cancels any prior heartbeat first. */
+  startHeartbeat(): void
+  /** Cancel the pending heartbeat (no-op if none). */
+  stopHeartbeat(): void
+  /** Stop the heartbeat, clear all tracked timers, and refuse further schedules. */
+  destroy(): void
+}
+
+export function createHeartbeatScheduler(options: HeartbeatSchedulerOptions): HeartbeatScheduler {
+  const { heartbeatDelayMs, demoMode, fire } = options
+  const scheduledTimers = new Set<number>()
+  let heartbeatTimer: number | null = null
+  let destroyed = false
+
+  function schedule(cb: () => void, delayMs: number): number {
+    if (destroyed) return 0
+    const id = window.setTimeout(() => {
+      scheduledTimers.delete(id)
+      if (!destroyed) cb()
+    }, delayMs)
+    scheduledTimers.add(id)
+    return id
+  }
+
+  function clearAll(): void {
+    scheduledTimers.forEach(id => clearTimeout(id))
+    scheduledTimers.clear()
+    heartbeatTimer = null
+  }
+
+  function stopHeartbeat(): void {
+    if (heartbeatTimer !== null) {
+      clearTimeout(heartbeatTimer)
+      scheduledTimers.delete(heartbeatTimer)
+      heartbeatTimer = null
+    }
+  }
+
+  function startHeartbeat(): void {
+    if (destroyed) return
+    stopHeartbeat()
+    const [hbMin, hbMax] = heartbeatDelayMs
+    const delay = demoMode
+      ? 8000 + Math.random() * 4000
+      : hbMin + Math.random() * (hbMax - hbMin)
+    heartbeatTimer = schedule(() => {
+      heartbeatTimer = null
+      void fire()
+    }, delay)
+  }
+
+  function destroy(): void {
+    destroyed = true
+    clearAll()
+  }
+
+  return { schedule, clearAll, startHeartbeat, stopHeartbeat, destroy }
+}


### PR DESCRIPTION
## What
- New `src/orchestrator/heartbeat-scheduler.ts` exporting `createHeartbeatScheduler(options)` factory + typed `HeartbeatScheduler` interface. Owns timer scheduling, the timer-tracking Set, and the heartbeat lifecycle (random min-max interval gating).
- `src/orchestrator.ts` now composes the scheduler for all tracked timeouts and the heartbeat. `fireHeartbeat` business logic stays in the orchestrator; the scheduler only drives cadence.
- New `src/__tests__/heartbeat-scheduler.test.ts` — 20 tests covering schedule/fire, multiple concurrent schedules, clearAll, startHeartbeat min-max + demoMode range, stop cancellation, destroy idempotency, destroyed-guard for late-firing callbacks, and instance isolation.

## Why
Task `W0-T003` — extract the heartbeat scheduler as the next incremental decomposition of the orchestrator god-module. Mirrors the `createTurnQueue` pattern from `W0-T002` (PR #227, in review) and sets up downstream splits (reaction router `W0-T006`, editor-lock `W0-T007`). Orthogonal file-by-file: turn-queue owns queue/processing/counters, this PR owns timers.

## Acceptance
- [x] `src/orchestrator/heartbeat-scheduler.ts` exports factory + typed interface
- [x] `src/orchestrator.ts` imports and uses it via `scheduler.schedule(cb, ms)`, `scheduler.clearAll()`, `scheduler.startHeartbeat()`, `scheduler.destroy()`; public orchestrator API unchanged
- [x] New test file covers schedule / clearAll / start-stop-destroy / min-interval gating / multiple concurrent schedules / leak prevention
- [x] lint + typecheck + test + build all green
- [x] Scope: only orchestrator.ts + two new files touched

## Verification
Locally on the worktree branch:
- `npm run lint` — passes (no warnings)
- `npm run typecheck` — passes
- `npm test` — 186/186 passing across 11 files (was 166/166 across 10 files; +20 tests from `heartbeat-scheduler.test.ts`)
- `npm run build` — passes (Vite build 3.39s)
- `orchestrator.test.ts` — 31/31 still passing (no regression in existing suite)
- `orchestrator.ts` LOC: 691 -> 668 (-23 lines net)

## Risk
**Low.** The extracted module is a pure timer coordinator — `window.setTimeout` wrapping, a tracking `Set`, a single heartbeat slot, and a destroyed-guard flag. No policy moved: orchestrator still decides when to start/stop the heartbeat, still owns `fireHeartbeat` logic (detectObservations, generateObservation, agent selection). The scheduler is injected with a `fire` callback, so the heartbeat continues to reach orchestrator state (queue, pausedAgents, phaseState) by closure — identical runtime behavior. All existing orchestrator tests (including destroy clears timers, user-message clears + reschedules heartbeat, heartbeat reschedules during processing) still pass unchanged.

## Tangle check with PR #227 (turn-queue)
Orthogonal at the file level. #227 touches `queue`, `processing`, `turnCount`, `exchangeCount` declarations and their call sites across `enqueue` / `processQueue` / the agent-tagged branch. This PR touches the `scheduledTimers`/`heartbeatTimer` declarations, `scheduleTimeout`/`clearAllTimers`/`startHeartbeat`/`stopHeartbeat`, and the two `scheduledTimers.forEach(...)` lines in `user-message`. Only `fireHeartbeat` is read by both PRs, and #227 only swaps `processing -> turnQueue.isProcessing()` inside it; merging either order produces a trivial rebase.

## Task
`W0-T003` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
