### PR TITLE
refactor: extract useOrchestratorWiring hook from App.tsx (W0-T010)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ import { WorkPlanCard } from './components/WorkPlanCard'
 import { resolvePresetTasks } from './task-presets'
 
 // Custom hooks
-import { useOrchestrator } from './hooks/useOrchestrator'
+import { useOrchestratorWiring } from './hooks/use-orchestrator-wiring'
 import { useSession, now, uid } from './hooks/useSession'
 import { useMarkupEditor } from './hooks/use-markup-editor'
 import { useSessionState } from './hooks/use-session-state'
@@ -83,7 +83,10 @@ function App() {
   const getAgentState = (name: string): AgentState => agentStates[name] || { status: 'idle', inDoc: false }
   const [timeline, setTimeline] = useState<TimelineEntry[]>([])
 
-  // Stable orchestrator ref -- shared between useMarkupEditor, useSession, and useOrchestrator
+  // Stable orchestrator ref -- shared between useMarkupEditor, useSession,
+  // and useOrchestratorWiring. Created at the App level because all three
+  // hooks need to read from / write to the same cell, and a ref is just a
+  // transport container.
   const orchestratorRef = useRef<ReturnType<typeof import('./orchestrator').createOrchestrator> | null>(null)
 
   // Session state hook -- owns activeSession/messages/tasks/agentStates +
@@ -184,8 +187,11 @@ function App() {
     }).catch(console.error)
   }, [activeSessionRef, setTasks, tasksRef])
 
-  // Orchestrator hook -- populates orchestratorRef
-  useOrchestrator({
+  // Orchestrator wiring hook -- owns orchestrator creation/destroy,
+  // callback subscriptions, message forwarding, and pause. Populates
+  // `orchestratorRef` so sibling hooks (useMarkupEditor, useSession) can
+  // trigger events.
+  const { pause: pauseOrchestrator } = useOrchestratorWiring({
     editorRef,
     messagesRef,
     activeAgents,
@@ -200,16 +206,9 @@ function App() {
     experimentSettings,
     tasksRef,
     onTaskAction: handleTaskAction,
+    messages,
+    lastProcessedMsgRef: lastProcessedMsg,
   })
-
-  // Forward new messages to orchestrator
-  useEffect(() => {
-    const newMsgs = messages.slice(lastProcessedMsg.current)
-    lastProcessedMsg.current = messages.length
-    for (const m of newMsgs) {
-      orchestratorRef.current?.onMessage(m.from, m.text)
-    }
-  }, [messages, orchestratorRef])
 
   const handleSendMessage = useCallback(() => {
     if (!input.trim()) return
@@ -328,14 +327,12 @@ function App() {
       const next = !v
       agentsPausedRef.current = next
       if (next) {
-        orchestratorRef.current?.destroy()
-        orchestratorRef.current = null
-        setAgentStates({})
+        pauseOrchestrator()
       }
-      // On unpause, useOrchestrator's useEffect will recreate and trigger doc-opened
+      // On unpause, useOrchestratorWiring's useEffect will recreate and trigger doc-opened
       return next
     })
-  }, [orchestratorRef, setAgentStates])
+  }, [pauseOrchestrator])
   useEffect(() => { togglePauseRef.current = handleTogglePause })
 
   // Legal pages -- accessible without auth

--- a/src/hooks/use-markup-editor.ts
+++ b/src/hooks/use-markup-editor.ts
@@ -51,7 +51,7 @@ export interface UseMarkupEditorResult {
  *
  * The hook's surface is deliberately minimal: it emits the editor plus two
  * refs (`editorRef`, `lastDocSnapshot`) that other hooks (useSession,
- * useOrchestrator) need to reach into. Session, messaging, and task callbacks
+ * useOrchestratorWiring) need to reach into. Session, messaging, and task callbacks
  * are intentionally *not* threaded through here — those belong in sibling
  * hooks.
  *

--- a/src/hooks/use-orchestrator-wiring.ts
+++ b/src/hooks/use-orchestrator-wiring.ts
@@ -1,18 +1,42 @@
-import { useCallback, useRef, useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { createOrchestrator } from '../orchestrator'
 import { saveChatMessage, updateSessionTitle } from '../lib/session-store'
 import { events } from '../lib/analytics'
-import type { AgentConfig, AgentState, Message, TimelineEntry, Session, EditProposalPayload, ExperimentSettings, AgentTask, TaskActionPayload } from '../types'
+import type {
+  AgentConfig,
+  AgentState,
+  AgentTask,
+  EditProposalPayload,
+  ExperimentSettings,
+  Message,
+  Session,
+  TaskActionPayload,
+  TimelineEntry,
+} from '../types'
 import type { Editor } from '@tiptap/react'
 import { now, uid } from './useSession'
 
-interface UseOrchestratorOptions {
+type OrchestratorHandle = ReturnType<typeof createOrchestrator>
+
+/**
+ * Inputs for {@link useOrchestratorWiring}. These come from sibling hooks:
+ * `useMarkupEditor` owns the editor ref, `useSessionState` owns the session /
+ * messages / tasks refs + setters, and App owns the pause toggle, the shared
+ * orchestrator transport ref, and the agent list.
+ */
+export interface UseOrchestratorWiringOptions {
   editorRef: React.RefObject<Editor | null>
   messagesRef: React.RefObject<Message[]>
   activeAgents: AgentConfig[]
   activeSessionRef: React.RefObject<Session | null>
   agentsPausedRef: React.RefObject<boolean>
-  orchestratorRef: React.MutableRefObject<ReturnType<typeof createOrchestrator> | null>
+  /**
+   * Shared cell holding the live orchestrator instance (or null while paused).
+   * Declared at the App level because sibling hooks (`useMarkupEditor` for
+   * user-typed `trigger`s, `useSession` for `doc-opened` after hydration)
+   * also need to read from it.
+   */
+  orchestratorRef: React.MutableRefObject<OrchestratorHandle | null>
   setAgentStates: React.Dispatch<React.SetStateAction<Record<string, AgentState>>>
   setTimeline: React.Dispatch<React.SetStateAction<TimelineEntry[]>>
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
@@ -21,29 +45,76 @@ interface UseOrchestratorOptions {
   experimentSettings?: ExperimentSettings
   tasksRef: React.RefObject<AgentTask[]>
   onTaskAction?: (agent: string, action: TaskActionPayload) => void
+  /**
+   * Chat stream — the hook watches this to forward new messages into
+   * `orchestrator.onMessage()` so agents can react to each other.
+   */
+  messages: Message[]
+  /**
+   * Cursor that tracks how many `messages` have already been forwarded.
+   * Owned by the caller (App.tsx) so session hydration can reset it to the
+   * restored-message count and avoid replaying server-side history.
+   */
+  lastProcessedMsgRef: React.MutableRefObject<number>
 }
 
-export function useOrchestrator({
-  editorRef,
-  messagesRef,
-  activeAgents,
-  activeSessionRef,
-  agentsPausedRef,
-  orchestratorRef,
-  setAgentStates,
-  setTimeline,
-  setMessages,
-  setSessions,
-  setActiveSession,
-  experimentSettings,
-  tasksRef,
-  onTaskAction,
-}: UseOrchestratorOptions) {
+export interface UseOrchestratorWiringResult {
+  /**
+   * Stable façade over the current orchestrator handle. Methods delegate to
+   * whatever orchestrator is live at call time, so callers never need to
+   * re-subscribe when the orchestrator is recreated after a pause/unpause or
+   * agent-config change.
+   */
+  orchestrator: OrchestratorHandle
+  /** Pause the orchestrator (destroys the current instance, clears agent states). */
+  pause: () => void
+}
+
+/**
+ * Wires App-level state into the orchestrator: subscribes the message /
+ * task / edit-proposal / rename / error callbacks, creates the orchestrator
+ * on mount (and on agent-config change), forwards new chat messages into
+ * `orchestrator.onMessage`, and destroys the orchestrator on unmount.
+ *
+ * Extracted from App.tsx so the main component no longer owns the
+ * orchestrator lifecycle. `useMarkupEditor` (W0-T008) and `useSessionState`
+ * (W0-T009) supply the refs this hook needs.
+ *
+ * The returned `orchestrator` façade is stable across orchestrator
+ * re-creations, so callers can pass the methods to `useCallback` deps
+ * without causing re-subscribe churn.
+ */
+export function useOrchestratorWiring(
+  options: UseOrchestratorWiringOptions,
+): UseOrchestratorWiringResult {
+  const {
+    editorRef,
+    messagesRef,
+    activeAgents,
+    activeSessionRef,
+    agentsPausedRef,
+    orchestratorRef,
+    setAgentStates,
+    setTimeline,
+    setMessages,
+    setSessions,
+    setActiveSession,
+    experimentSettings,
+    tasksRef,
+    onTaskAction,
+    messages,
+    lastProcessedMsgRef,
+  } = options
+
   const pendingReasoning = useRef<Record<string, string[]>>({})
   const prevAgentsRef = useRef<AgentConfig[]>(activeAgents)
+  const hasInitialized = useRef(false)
+
+  // Keep the task-action callback addressable from within the orchestrator
+  // config closure without retriggering orchestrator re-creation every time
+  // App's `handleTaskAction` re-memoizes.
   const onTaskActionRef = useRef(onTaskAction)
   useEffect(() => { onTaskActionRef.current = onTaskAction })
-  const hasInitialized = useRef(false)
 
   const makeOrchestrator = useCallback(() => {
     return createOrchestrator({
@@ -138,8 +209,23 @@ export function useOrchestrator({
         }
       },
     })
-  }, [activeAgents, editorRef, messagesRef, activeSessionRef, setAgentStates, setTimeline, setMessages, setSessions, setActiveSession, experimentSettings, tasksRef])
+  }, [
+    activeAgents,
+    editorRef,
+    messagesRef,
+    activeSessionRef,
+    setAgentStates,
+    setTimeline,
+    setMessages,
+    setSessions,
+    setActiveSession,
+    experimentSettings,
+    tasksRef,
+  ])
 
+  // Orchestrator lifecycle: create on mount / on agent-config change, destroy
+  // on unmount. Pause is handled by the caller via the returned `pause` fn,
+  // which nulls the ref so this effect's cleanup skips the redundant destroy.
   useEffect(() => {
     if (agentsPausedRef.current) return
 
@@ -148,14 +234,15 @@ export function useOrchestrator({
 
     // Only trigger doc-opened on first init or agent config change (not on settings tweaks)
     const prevAgents = prevAgentsRef.current
-    const agentsChanged = activeAgents.length !== prevAgents.length || activeAgents.some(a => !prevAgents.some(p => p.name === a.name))
+    const agentsChanged = activeAgents.length !== prevAgents.length
+      || activeAgents.some(a => !prevAgents.some(p => p.name === a.name))
     if (!hasInitialized.current || agentsChanged) {
       orch.trigger('doc-opened')
       hasInitialized.current = true
       if (agentsChanged && prevAgents.length > 0) {
         const newAgentNames = activeAgents.filter(a => !prevAgents.some(p => p.name === a.name)).map(a => a.name)
         if (newAgentNames.length > 0) {
-          if (import.meta.env.DEV) console.log('[useOrchestrator] new agents activated:', newAgentNames.join(', '))
+          if (import.meta.env.DEV) console.log('[useOrchestratorWiring] new agents activated:', newAgentNames.join(', '))
           events.agentConfigChanged(activeAgents.length, activeAgents.map(a => a.name))
         }
       }
@@ -170,7 +257,35 @@ export function useOrchestrator({
     }
   }, [makeOrchestrator, agentsPausedRef, orchestratorRef, activeAgents])
 
-  return {
-    makeOrchestrator,
-  }
+  // Forward newly-arrived chat messages into the orchestrator so agents can
+  // react to each other. The cursor is owned by the caller so session
+  // hydration (useSession.handleSessionSelect) can reset it to the restored
+  // message count and skip replaying history.
+  useEffect(() => {
+    const newMsgs = messages.slice(lastProcessedMsgRef.current)
+    lastProcessedMsgRef.current = messages.length
+    for (const m of newMsgs) {
+      orchestratorRef.current?.onMessage(m.from, m.text)
+    }
+  }, [messages, lastProcessedMsgRef, orchestratorRef])
+
+  const pause = useCallback(() => {
+    orchestratorRef.current?.destroy()
+    orchestratorRef.current = null
+    setAgentStates({})
+  }, [orchestratorRef, setAgentStates])
+
+  // Stable façade over the (possibly swapped) orchestrator instance. Methods
+  // read through `orchestratorRef` at call time, so downstream `useCallback`
+  // deps never churn just because the orchestrator was recreated after
+  // pause/unpause or an agent-config change. `orchestratorRef` is a stable
+  // ref, so this memo never invalidates.
+  const orchestrator = useMemo<OrchestratorHandle>(() => ({
+    trigger: (type, payload) => orchestratorRef.current?.trigger(type, payload),
+    onMessage: (from, text) => orchestratorRef.current?.onMessage(from, text),
+    applyApprovedEdit: (agent, payload) => orchestratorRef.current?.applyApprovedEdit(agent, payload),
+    destroy: () => orchestratorRef.current?.destroy(),
+  }), [orchestratorRef])
+
+  return { orchestrator, pause }
 }


### PR DESCRIPTION
## What
- New `src/hooks/use-orchestrator-wiring.ts` owns orchestrator creation/destroy, callback subscriptions (message/task/proposal/error/rename), chat-message forwarding into `orchestrator.onMessage`, and the pause destroy path
- App.tsx drops the inline message-forwarding `useEffect` and inline `handleTogglePause` destroy logic in favour of the hook's `pause()` callback; the previous `useOrchestrator` hook is renamed and extended rather than layered
- Sibling hooks (`useSession`, `useMarkupEditor`) keep receiving `orchestratorRef` as an option — the ref is still the cross-hook transport, now documented as such at the one place it is declared

## Why
Completes the App.tsx split started in W0-T008 (`useMarkupEditor`) and W0-T009 (`useSessionState`). Reference: `orchestration/plan.md` → **W0-T010 — Split App.tsx: extract orchestrator wiring hook**.

## Acceptance
- [x] `src/hooks/use-orchestrator-wiring.ts` exports `useOrchestratorWiring`
- [x] App.tsx uses it; no inline orchestrator wiring remains (no inline subscription `useEffect`, no inline destroy in `handleTogglePause`)
- [x] No behavior change — orchestrator is still created on mount / agent-config change, paused via toggle, messages still forward in order, `applyApprovedEdit` still wired from TamboChat
- [x] Dev server boots cleanly, HTTP 200 OK

## Verification
- `npm run lint` — clean
- `npm run build` — passes (tsc -b + vite prod build)
- `npm test` — 294 passed across 13 files
- `npm run dev` — Vite ready, `curl http://localhost:5173/` returned `HTTP/1.1 200 OK`
- No new React-DOM test infra added (none exists in the repo yet; same situation as W0-T008/T009) — hook behaviour is covered indirectly by the existing `orchestrator.test.ts` / `agent-actions.test.ts` suites which drive the same `createOrchestrator` surface this hook composes

## Risk
**Low.** Pure move of existing code. The returned `orchestrator` is a stable `useMemo` façade that reads through `orchestratorRef` at call time, so downstream `useCallback` deps are unchanged in cardinality (no new churn). One subtle detail worth reviewer eyes: the lifecycle `useEffect` reads `agentsPausedRef.current` on mount and skips creation when paused — same as before — and `pause()` nulls the ref so the effect cleanup's `destroy()` is skipped when the orchestrator was already torn down.

## Task
`W0-T010` in `orchestration/queue.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
