### PR TITLE
feat: keyboard shortcuts help modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3983,9 +3983,11 @@
   backdrop-filter: blur(4px);
 }
 
-/* Keyboard-shortcuts help modal. Shares the overlay look/feel with .exp-overlay. */
+/* Keyboard-shortcuts help modal. Shares the overlay look/feel with .exp-overlay.
+   Z-index aligned with template-picker/command-palette (10000) so if ? is hit
+   while another modal is already open, the help surface isn't rendered behind it. */
 .kbd-help-overlay {
-  position: fixed; inset: 0; z-index: 200;
+  position: fixed; inset: 0; z-index: 10000;
   background: rgba(0, 0, 0, 0.6);
   display: flex; align-items: center; justify-content: center;
   backdrop-filter: blur(4px);

--- a/src/App.css
+++ b/src/App.css
@@ -3982,6 +3982,65 @@
   display: flex; align-items: center; justify-content: center;
   backdrop-filter: blur(4px);
 }
+
+/* Keyboard-shortcuts help modal. Shares the overlay look/feel with .exp-overlay. */
+.kbd-help-overlay {
+  position: fixed; inset: 0; z-index: 200;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex; align-items: center; justify-content: center;
+  backdrop-filter: blur(4px);
+}
+.kbd-help-panel {
+  background: var(--surface-1);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  width: 360px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+.kbd-help-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.kbd-help-title {
+  font-size: 14px; font-weight: 600; color: var(--text-primary);
+  margin: 0;
+}
+.kbd-help-close {
+  display: flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  background: none; border: none; cursor: pointer;
+  color: var(--text-tertiary);
+  border-radius: var(--radius-xs);
+}
+.kbd-help-close:hover { color: var(--text-primary); background: var(--surface-2); }
+.kbd-help-list {
+  margin: 0;
+  padding: 10px 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.kbd-help-row {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  align-items: center;
+  gap: 14px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.kbd-help-row dt { margin: 0; }
+.kbd-help-row dd { margin: 0; }
+.kbd-help-row kbd {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 3px 7px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  color: var(--text-primary);
+}
 .exp-panel {
   background: var(--surface-1);
   border: 1px solid var(--border-default);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ const LegalPage = lazy(() => import('./LegalPage').then(m => ({ default: m.Legal
 const TemplatePickerModal = lazy(() => import('./TemplatePickerModal').then(m => ({ default: m.TemplatePickerModal })))
 import type { GoogleDocFile } from './TemplatePickerModal'
 const ExperimentControls = lazy(() => import('./ExperimentControls').then(m => ({ default: m.ExperimentControls })))
+const KeyboardShortcutsModal = lazy(() => import('./components/KeyboardShortcutsModal').then(m => ({ default: m.KeyboardShortcutsModal })))
 import { updateSessionTitle, saveChatMessage, saveAgentTasks, updateAgentTask, subscribeToDocument } from './lib/session-store'
 import { identify, events } from './lib/analytics'
 import { TamboProvider } from '@tambo-ai/react'
@@ -68,6 +69,7 @@ function App() {
 
   const [showTemplatePicker, setShowTemplatePicker] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
+  const [showShortcutsHelp, setShowShortcutsHelp] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [sidebarWidth, setSidebarWidth] = useState(240)
   const [chatWidth, setChatWidth] = useState(340)
@@ -247,6 +249,7 @@ function App() {
     toggleSettings: () => setShowExperiments(v => !v),
     toggleSidebar: () => setSidebarCollapsed(v => !v),
     togglePause: () => togglePauseRef.current(),
+    toggleShortcutsHelp: () => setShowShortcutsHelp(v => !v),
   })
 
   const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
@@ -566,6 +569,11 @@ function App() {
             { setShowTemplatePicker, handleTogglePause, setShowConfigurator, setSidebarCollapsed, setShowExperiments, resetToHome, setMessages, toast, signOut, uid, now },
           )}
         />
+      )}
+      {showShortcutsHelp && (
+        <Suspense>
+          <KeyboardShortcutsModal onClose={() => setShowShortcutsHelp(false)} />
+        </Suspense>
       )}
     </div>
   )

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -12,7 +12,7 @@ const SHORTCUTS: Shortcut[] = [
   { keys: '\u2318 \\', label: 'Toggle sidebar' },
   { keys: '\u2318 \u21E7 P', label: 'Pause or resume agents' },
   { keys: '?', label: 'Show this help' },
-  { keys: 'Esc', label: 'Close any modal' },
+  { keys: 'Esc', label: 'Close this dialog' },
 ]
 
 interface Props {

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef } from 'react'
+
+interface Shortcut {
+  keys: string
+  label: string
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { keys: '\u2318 N', label: 'New document' },
+  { keys: '\u2318 K', label: 'Open command palette' },
+  { keys: '\u2318 ,', label: 'Open settings' },
+  { keys: '\u2318 \\', label: 'Toggle sidebar' },
+  { keys: '\u2318 \u21E7 P', label: 'Pause or resume agents' },
+  { keys: '?', label: 'Show this help' },
+  { keys: 'Esc', label: 'Close any modal' },
+]
+
+interface Props {
+  onClose: () => void
+}
+
+export function KeyboardShortcutsModal({ onClose }: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  return (
+    <div
+      className="kbd-help-overlay"
+      ref={overlayRef}
+      onClick={e => { if (e.target === overlayRef.current) onClose() }}
+    >
+      <div className="kbd-help-panel" role="dialog" aria-modal="true" aria-labelledby="kbd-help-title">
+        <div className="kbd-help-header">
+          <h2 className="kbd-help-title" id="kbd-help-title">Keyboard shortcuts</h2>
+          <button type="button" className="kbd-help-close" onClick={onClose} aria-label="Close">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+        <dl className="kbd-help-list">
+          {SHORTCUTS.map(s => (
+            <div key={s.keys} className="kbd-help-row">
+              <dt><kbd>{s.keys}</kbd></dt>
+              <dd>{s.label}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -26,8 +26,11 @@ export function useKeyboardShortcuts(actions: ShortcutActions) {
       if (mod && e.key === ',') { e.preventDefault(); toggleSettings() }
       if (mod && e.key === '\\') { e.preventDefault(); toggleSidebar() }
       if (mod && e.shiftKey && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); togglePauseRef.current() }
-      // "?" only fires outside input/contenteditable, and not when a modifier is held.
-      if (!mod && e.key === '?' && toggleShortcutsHelpRef.current) {
+      // "?" fires only with plain Shift (typing the character). Skip when
+      // Ctrl/Meta/Alt is held to avoid stealing platform shortcuts and
+      // non-US keyboard layout compositions. Also skip when focus is in
+      // an editable element so typing "?" in prose still works.
+      if (!mod && !e.altKey && e.key === '?' && toggleShortcutsHelpRef.current) {
         const target = e.target as HTMLElement | null
         const tag = target?.tagName
         const editable = target?.isContentEditable

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -6,14 +6,17 @@ interface ShortcutActions {
   toggleSettings: () => void
   toggleSidebar: () => void
   togglePause: () => void
+  toggleShortcutsHelp?: () => void
 }
 
 export function useKeyboardShortcuts(actions: ShortcutActions) {
-  const { newDoc, toggleCommandPalette, toggleSettings, toggleSidebar, togglePause } = actions
+  const { newDoc, toggleCommandPalette, toggleSettings, toggleSidebar, togglePause, toggleShortcutsHelp } = actions
 
   // Use ref for togglePause to avoid stale closure issues
   const togglePauseRef = useRef(togglePause)
   useEffect(() => { togglePauseRef.current = togglePause })
+  const toggleShortcutsHelpRef = useRef(toggleShortcutsHelp)
+  useEffect(() => { toggleShortcutsHelpRef.current = toggleShortcutsHelp })
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -23,6 +26,15 @@ export function useKeyboardShortcuts(actions: ShortcutActions) {
       if (mod && e.key === ',') { e.preventDefault(); toggleSettings() }
       if (mod && e.key === '\\') { e.preventDefault(); toggleSidebar() }
       if (mod && e.shiftKey && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); togglePauseRef.current() }
+      // "?" only fires outside input/contenteditable, and not when a modifier is held.
+      if (!mod && e.key === '?' && toggleShortcutsHelpRef.current) {
+        const target = e.target as HTMLElement | null
+        const tag = target?.tagName
+        const editable = target?.isContentEditable
+        if (editable || tag === 'INPUT' || tag === 'TEXTAREA') return
+        e.preventDefault()
+        toggleShortcutsHelpRef.current()
+      }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)


### PR DESCRIPTION
## Summary
Press `?` (outside any input) to see the full keyboard-shortcut list in a modal. Escape or click outside closes it.

- New `src/components/KeyboardShortcutsModal.tsx` — lazy-loaded, `role="dialog"` + `aria-modal`, labeled close button.
- `useKeyboardShortcuts` gains an optional `toggleShortcutsHelp` action; the `?` handler ignores keypresses that originate inside inputs, textareas, or contenteditable targets so it doesn't hijack typing.
- Styling shares the established overlay pattern (`.kbd-help-overlay`).

Lists `⌘N`, `⌘K`, `⌘,`, `⌘\`, `⌘⇧P`, `?`, and `Esc`.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes
- [x] Pressing `?` with the editor or any input focused does not open the modal
- [x] Pressing `?` on the home view does

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
