### PR TITLE
feat: htmlToMarkdown + downloadMarkdown utilities

### DIFF
--- a/src/__tests__/doc-export.test.ts
+++ b/src/__tests__/doc-export.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { htmlToMarkdown } from '../lib/doc-export'
+
+describe('htmlToMarkdown', () => {
+  it('renders headings', () => {
+    expect(htmlToMarkdown('<h1>Hello</h1>')).toBe('# Hello\n')
+    expect(htmlToMarkdown('<h2>Sub</h2>')).toBe('## Sub\n')
+  })
+
+  it('renders paragraphs', () => {
+    expect(htmlToMarkdown('<p>one</p><p>two</p>')).toBe('one\n\ntwo\n')
+  })
+
+  it('renders inline formatting', () => {
+    expect(htmlToMarkdown('<p>a <strong>b</strong> <em>c</em> <code>d</code></p>'))
+      .toBe('a **b** _c_ `d`\n')
+  })
+
+  it('renders links', () => {
+    expect(htmlToMarkdown('<p>see <a href="https://x.com">x</a></p>'))
+      .toBe('see [x](https://x.com)\n')
+  })
+
+  it('renders unordered lists', () => {
+    expect(htmlToMarkdown('<ul><li>one</li><li>two</li></ul>'))
+      .toBe('- one\n- two\n')
+  })
+
+  it('renders ordered lists', () => {
+    expect(htmlToMarkdown('<ol><li>a</li><li>b</li></ol>'))
+      .toBe('1. a\n2. b\n')
+  })
+
+  it('renders code blocks with language hint', () => {
+    const out = htmlToMarkdown('<pre><code class="language-ts">const x = 1</code></pre>')
+    expect(out).toBe('```ts\nconst x = 1\n```\n')
+  })
+
+  it('renders blockquotes', () => {
+    expect(htmlToMarkdown('<blockquote><p>quoted</p></blockquote>'))
+      .toBe('> quoted\n')
+  })
+
+  it('renders horizontal rule', () => {
+    expect(htmlToMarkdown('<hr/>')).toBe('---\n')
+  })
+
+  it('decodes html entities', () => {
+    expect(htmlToMarkdown('<p>Tom &amp; Jerry &lt;3</p>')).toBe('Tom & Jerry <3\n')
+  })
+
+  it('prepends title when provided', () => {
+    expect(htmlToMarkdown('<p>body</p>', { title: 'Hello' }))
+      .toBe('# Hello\n\nbody\n')
+  })
+
+  it('gracefully handles unknown tags', () => {
+    expect(htmlToMarkdown('<p>a <span>b</span> c</p>')).toBe('a b c\n')
+  })
+})

--- a/src/__tests__/doc-export.test.ts
+++ b/src/__tests__/doc-export.test.ts
@@ -68,6 +68,25 @@ describe('htmlToMarkdown', () => {
     // would render empty because unknown top-level text is dropped.
     expect(htmlToMarkdown('<p>hello')).toBe('hello\n')
   })
+
+  it('picks inline-code delimiter longer than any backtick run in content', () => {
+    // Content contains a single backtick; delimiter must be >=2.
+    expect(htmlToMarkdown('<p><code>a`b</code></p>')).toBe('``a`b``\n')
+  })
+
+  it('pads inline code when content starts or ends with a backtick', () => {
+    // CommonMark requires a space between delimiter and leading/trailing `.
+    expect(htmlToMarkdown('<p><code>`x</code></p>')).toBe('`` `x ``\n')
+  })
+
+  it('picks fence longer than any internal triple-backtick', () => {
+    const inner = 'before\n```\nafter'
+    const out = htmlToMarkdown('<pre><code>' + inner + '</code></pre>')
+    // Fence must be >=4 backticks (one longer than the internal 3).
+    expect(out.startsWith('````\n')).toBe(true)
+    expect(out.endsWith('````\n')).toBe(true)
+    expect(out).toContain(inner)
+  })
 })
 
 describe('downloadMarkdown', () => {

--- a/src/__tests__/doc-export.test.ts
+++ b/src/__tests__/doc-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { htmlToMarkdown } from '../lib/doc-export'
+import { htmlToMarkdown, downloadMarkdown } from '../lib/doc-export'
 
 describe('htmlToMarkdown', () => {
   it('renders headings', () => {
@@ -56,5 +56,29 @@ describe('htmlToMarkdown', () => {
 
   it('gracefully handles unknown tags', () => {
     expect(htmlToMarkdown('<p>a <span>b</span> c</p>')).toBe('a b c\n')
+  })
+
+  it('decodes entities in href attributes so URLs round-trip', () => {
+    expect(htmlToMarkdown('<p><a href="https://x.com/?a=1&amp;b=2">q</a></p>'))
+      .toBe('[q](https://x.com/?a=1&b=2)\n')
+  })
+
+  it('attaches trailing text on unclosed tags to the open element', () => {
+    // If the parser mistakenly attached tail text to root, <p>hello
+    // would render empty because unknown top-level text is dropped.
+    expect(htmlToMarkdown('<p>hello')).toBe('hello\n')
+  })
+})
+
+describe('downloadMarkdown', () => {
+  it('returns false when document is undefined', () => {
+    const globalRef = globalThis as unknown as { document?: unknown }
+    const original = globalRef.document
+    delete globalRef.document
+    try {
+      expect(downloadMarkdown('x.md', '# hi')).toBe(false)
+    } finally {
+      globalRef.document = original
+    }
   })
 })

--- a/src/lib/doc-export.ts
+++ b/src/lib/doc-export.ts
@@ -13,14 +13,15 @@
  *   - inline: strong, em, code, links
  *
  * The editor never emits tables or raw script/style, so those aren't
- * handled. If unexpected HTML appears, the function preserves the inner
- * text without the tags.
+ * handled. Unknown *inline* tags nested inside a known block have
+ * their text preserved; unknown *top-level* tags are dropped entirely
+ * because there's no obvious way to render them as Markdown blocks.
  */
 
 interface Options {
   /**
-   * Prepend a YAML-ish title front-matter with the doc title. Leave
-   * blank to skip.
+   * Prepend the doc title as a Markdown H1 (`# title`). Leave blank
+   * to skip.
    */
   title?: string
 }
@@ -61,7 +62,9 @@ function parseHtml(input: string): ParsedNode {
     const re = /([a-zA-Z-]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g
     let m: RegExpExecArray | null
     while ((m = re.exec(raw)) !== null) {
-      attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? m[4] ?? ''
+      const val = m[2] ?? m[3] ?? m[4] ?? ''
+      // Decode so href="...?a=1&amp;b=2" round-trips to ...?a=1&b=2 in the link.
+      attrs[m[1].toLowerCase()] = decodeEntities(val)
     }
     return attrs
   }
@@ -93,7 +96,9 @@ function parseHtml(input: string): ParsedNode {
     lastIndex = tagRe.lastIndex
   }
   const tail = input.slice(lastIndex)
-  if (tail) root.children.push(decodeEntities(tail))
+  // Trailing text on an unclosed tag (e.g. `<p>hello`) must attach to
+  // the currently-open element so nothing leaks to the root.
+  if (tail) stack[stack.length - 1].children.push(decodeEntities(tail))
   return root
 }
 

--- a/src/lib/doc-export.ts
+++ b/src/lib/doc-export.ts
@@ -31,6 +31,25 @@ const BLOCK_TAGS = new Set([
   'ul', 'ol', 'li', 'blockquote', 'pre', 'hr',
 ])
 
+/**
+ * Pick a backtick delimiter longer than the longest run of backticks
+ * in `content` so the fence/inline-code can't be closed early by its
+ * own payload. Used for both inline code and fenced blocks.
+ *
+ * For inline code, Markdown also requires a space between the
+ * delimiter and leading/trailing backticks — we handle that at the
+ * call site.
+ */
+function pickBacktickFence(content: string, minLen = 1): string {
+  let longest = 0
+  const re = /`+/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(content)) !== null) {
+    if (m[0].length > longest) longest = m[0].length
+  }
+  return '`'.repeat(Math.max(minLen, longest + 1))
+}
+
 interface ParsedNode {
   tag: string
   attrs: Record<string, string>
@@ -112,8 +131,13 @@ function renderInline(node: ParsedNode | string): string {
     case 'em':
     case 'i':
       return `_${inner}_`
-    case 'code':
-      return `\`${inner}\``
+    case 'code': {
+      // Choose delimiter long enough to avoid collision; if inner starts
+      // or ends with a backtick, pad with a space per CommonMark.
+      const fence = pickBacktickFence(inner)
+      const needsPad = inner.startsWith('`') || inner.endsWith('`')
+      return needsPad ? `${fence} ${inner} ${fence}` : `${fence}${inner}${fence}`
+    }
     case 'a': {
       const href = node.attrs.href || ''
       return href ? `[${inner}](${href})` : inner
@@ -166,8 +190,14 @@ function renderBlock(node: ParsedNode, depth = 0): string {
         (c): c is ParsedNode => typeof c !== 'string' && c.tag === 'code',
       )
       const lang = codeChild?.attrs.class?.match(/language-(\S+)/)?.[1] ?? ''
-      const body = codeChild ? codeChild.children.map(renderInline).join('') : node.children.map(renderInline).join('')
-      return '```' + lang + '\n' + body + '\n```'
+      // Walk code content literally so backticks aren't wrapped in
+      // another `code` fence and then collapsed — we want raw.
+      const body = codeChild
+        ? codeChild.children.map(c => typeof c === 'string' ? c : renderInline(c)).join('')
+        : node.children.map(c => typeof c === 'string' ? c : renderInline(c)).join('')
+      // Pick a fence longer than the longest internal backtick run.
+      const fence = pickBacktickFence(body, 3)
+      return fence + lang + '\n' + body + '\n' + fence
     }
     default:
       return node.children.map(renderInline).join('')

--- a/src/lib/doc-export.ts
+++ b/src/lib/doc-export.ts
@@ -1,0 +1,207 @@
+/**
+ * Convert Tiptap's HTML output to a compact, human-readable Markdown
+ * string. Keeps the handful of block elements the editor actually emits
+ * (StarterKit nodes) and is intentionally lossy for everything else.
+ *
+ * This is a pure, DOM-free implementation so it runs in tests and in
+ * SSR contexts. It handles:
+ *   - h1-h6, paragraphs, line breaks, horizontal rules
+ *   - unordered + ordered lists (flat; nested lists are supported one
+ *     level via indentation)
+ *   - blockquote (prefixes every inner paragraph with `> `)
+ *   - pre/code blocks (fenced, with language hint if present)
+ *   - inline: strong, em, code, links
+ *
+ * The editor never emits tables or raw script/style, so those aren't
+ * handled. If unexpected HTML appears, the function preserves the inner
+ * text without the tags.
+ */
+
+interface Options {
+  /**
+   * Prepend a YAML-ish title front-matter with the doc title. Leave
+   * blank to skip.
+   */
+  title?: string
+}
+
+const BLOCK_TAGS = new Set([
+  'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li', 'blockquote', 'pre', 'hr',
+])
+
+interface ParsedNode {
+  tag: string
+  attrs: Record<string, string>
+  children: (ParsedNode | string)[]
+}
+
+/** Tiny HTML parser tuned to the subset Tiptap StarterKit emits. */
+function parseHtml(input: string): ParsedNode {
+  const root: ParsedNode = { tag: 'root', attrs: {}, children: [] }
+  const stack: ParsedNode[] = [root]
+  const voidTags = new Set(['br', 'hr', 'img'])
+
+  const tagRe = /<\/?([a-zA-Z][a-zA-Z0-9]*)([^>]*)\/?>/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  const decodeEntities = (s: string) =>
+    s
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&apos;/g, "'")
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
+
+  const parseAttrs = (raw: string): Record<string, string> => {
+    const attrs: Record<string, string> = {}
+    const re = /([a-zA-Z-]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(raw)) !== null) {
+      attrs[m[1].toLowerCase()] = m[2] ?? m[3] ?? m[4] ?? ''
+    }
+    return attrs
+  }
+
+  while ((match = tagRe.exec(input)) !== null) {
+    const text = input.slice(lastIndex, match.index)
+    if (text) stack[stack.length - 1].children.push(decodeEntities(text))
+    const [full, tag] = match
+    const tagName = tag.toLowerCase()
+    const isClose = full.startsWith('</')
+    const isSelfClose = full.endsWith('/>') || voidTags.has(tagName)
+
+    if (isClose) {
+      for (let i = stack.length - 1; i > 0; i--) {
+        if (stack[i].tag === tagName) {
+          stack.length = i
+          break
+        }
+      }
+    } else {
+      const node: ParsedNode = {
+        tag: tagName,
+        attrs: parseAttrs(match[2] || ''),
+        children: [],
+      }
+      stack[stack.length - 1].children.push(node)
+      if (!isSelfClose) stack.push(node)
+    }
+    lastIndex = tagRe.lastIndex
+  }
+  const tail = input.slice(lastIndex)
+  if (tail) root.children.push(decodeEntities(tail))
+  return root
+}
+
+function renderInline(node: ParsedNode | string): string {
+  if (typeof node === 'string') return node
+  const inner = node.children.map(renderInline).join('')
+  switch (node.tag) {
+    case 'strong':
+    case 'b':
+      return `**${inner}**`
+    case 'em':
+    case 'i':
+      return `_${inner}_`
+    case 'code':
+      return `\`${inner}\``
+    case 'a': {
+      const href = node.attrs.href || ''
+      return href ? `[${inner}](${href})` : inner
+    }
+    case 'br':
+      return '\n'
+    case 'span':
+      return inner
+    default:
+      return inner
+  }
+}
+
+function renderBlock(node: ParsedNode, depth = 0): string {
+  if (typeof node === 'string') return node
+  const indent = '  '.repeat(depth)
+  switch (node.tag) {
+    case 'h1': case 'h2': case 'h3': case 'h4': case 'h5': case 'h6': {
+      const level = Number(node.tag.slice(1))
+      return `${'#'.repeat(level)} ${node.children.map(renderInline).join('')}`
+    }
+    case 'p':
+      return node.children.map(renderInline).join('')
+    case 'hr':
+      return '---'
+    case 'ul':
+    case 'ol': {
+      const ordered = node.tag === 'ol'
+      return node.children
+        .filter((c): c is ParsedNode => typeof c !== 'string' && c.tag === 'li')
+        .map((li, i) => {
+          const marker = ordered ? `${i + 1}.` : '-'
+          const liContent = li.children.map(c => {
+            if (typeof c !== 'string' && (c.tag === 'ul' || c.tag === 'ol')) {
+              return '\n' + renderBlock(c, depth + 1)
+            }
+            return renderInline(c)
+          }).join('')
+          return `${indent}${marker} ${liContent.trim()}`
+        })
+        .join('\n')
+    }
+    case 'blockquote':
+      return node.children
+        .filter((c): c is ParsedNode => typeof c !== 'string')
+        .map(c => renderBlock(c, depth).split('\n').map(l => `> ${l}`).join('\n'))
+        .join('\n\n')
+    case 'pre': {
+      const codeChild = node.children.find(
+        (c): c is ParsedNode => typeof c !== 'string' && c.tag === 'code',
+      )
+      const lang = codeChild?.attrs.class?.match(/language-(\S+)/)?.[1] ?? ''
+      const body = codeChild ? codeChild.children.map(renderInline).join('') : node.children.map(renderInline).join('')
+      return '```' + lang + '\n' + body + '\n```'
+    }
+    default:
+      return node.children.map(renderInline).join('')
+  }
+}
+
+export function htmlToMarkdown(html: string, options: Options = {}): string {
+  const root = parseHtml(html)
+  const parts: string[] = []
+  if (options.title) parts.push(`# ${options.title}`)
+  for (const child of root.children) {
+    if (typeof child === 'string') {
+      const t = child.trim()
+      if (t) parts.push(t)
+      continue
+    }
+    if (BLOCK_TAGS.has(child.tag)) {
+      const rendered = renderBlock(child).trim()
+      if (rendered) parts.push(rendered)
+    }
+    // unknown top-level tags fall through silently — lossy by design
+  }
+  return parts.join('\n\n').trim() + '\n'
+}
+
+/**
+ * Trigger a browser download of the given markdown. Safe no-op on
+ * non-browser runtimes (returns false).
+ */
+export function downloadMarkdown(filename: string, markdown: string): boolean {
+  if (typeof document === 'undefined' || typeof URL === 'undefined') return false
+  const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+  return true
+}


### PR DESCRIPTION
## Summary
Adds `htmlToMarkdown(html, { title? })` and `downloadMarkdown(filename, md)` in `src/lib/doc-export.ts`. Pure, DOM-free HTML parser tuned to the subset Tiptap StarterKit emits: headings, paragraphs, ordered/unordered lists (one-level nesting), blockquote, code blocks (with `language-xx` class preservation), horizontal rules, and inline `strong`/`em`/`code`/`a`.

`downloadMarkdown` uses Blob + `URL.createObjectURL` and no-ops gracefully in non-browser runtimes (returns `false`).

Shipping the utility first so a UI wiring PR (command palette entry, or header button) can consume it. Ships with **12 unit tests** covering headings, inline formatting, links, lists, code fences with language, blockquotes, HR, entity decoding, optional title, and unknown-tag fallback.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (329 tests, +12 new)

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
