### PR TITLE
feat(db): decision-ledger migration + types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,11 @@ export interface AgentPersonaRecord {
  * docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md
  * (lens 2, "A decision ledger"). Kept intentionally loose — the
  * `entry` payload is a JSON record while the UI and affordances
- * stabilize.
+ * stabilize. The authoritative proposer lives on
+ * `DecisionRecord.proposed_by`, not here, so there's a single source
+ * of truth.
  */
 export interface DecisionEntry {
-  proposer: string
   objector?: string
   adopter?: string
   alternative?: string
@@ -40,8 +41,11 @@ export interface DecisionEntry {
 export interface DecisionRecord {
   id: string
   session_id: string
-  paragraph_anchor?: string | null
+  /** Heading or span identifier the decision attaches to. Nullable to
+   *  match the Supabase row shape (not optional). */
+  paragraph_anchor: string | null
   entry: DecisionEntry
+  /** Authoritative proposer — human username or agent name. */
   proposed_by: string
   created_at: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,31 @@ export interface AgentPersonaRecord {
   sort_order: number
 }
 
+/**
+ * An append-only entry in the per-session decision ledger. See
+ * docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md
+ * (lens 2, "A decision ledger"). Kept intentionally loose — the
+ * `entry` payload is a JSON record while the UI and affordances
+ * stabilize.
+ */
+export interface DecisionEntry {
+  proposer: string
+  objector?: string
+  adopter?: string
+  alternative?: string
+  confidence?: number
+  rationale?: string
+}
+
+export interface DecisionRecord {
+  id: string
+  session_id: string
+  paragraph_anchor?: string | null
+  entry: DecisionEntry
+  proposed_by: string
+  created_at: string
+}
+
 export interface ChatMessageRecord {
   id: string
   session_id: string

--- a/supabase/migrations/006_decision_ledger.sql
+++ b/supabase/migrations/006_decision_ledger.sql
@@ -11,33 +11,43 @@ create table if not exists decisions (
   id uuid primary key default gen_random_uuid(),
   session_id uuid references sessions(id) on delete cascade not null,
   paragraph_anchor text,          -- optional heading or span identifier
-  entry jsonb not null,           -- { proposer, objector?, adopter?, alternative?, confidence?, rationale }
-  proposed_by text not null,      -- human username or agent name
+  entry jsonb not null,           -- { objector?, adopter?, alternative?, confidence?, rationale } — proposer lives in proposed_by (below)
+  proposed_by text not null,      -- authoritative proposer: human username or agent name
   created_at timestamptz not null default now()
 );
 
 create index if not exists idx_decisions_session
   on decisions(session_id, created_at);
 
--- RLS: user owns decisions via session ownership, matching agent_tasks.
+-- RLS: user owns decisions via session ownership. Append-only:
+-- SELECT + INSERT only — no UPDATE/DELETE policies, so mutations are
+-- denied by default and ledger history is immutable at the DB layer.
+-- Ownership is strict (auth.uid() = sessions.user_id); we do not
+-- include the "or user_id is null" anon-session shortcut here.
 alter table decisions enable row level security;
 
 drop policy if exists "decisions_owner_all" on decisions;
-create policy "decisions_owner_all" on decisions
-  for all
+drop policy if exists "decisions_owner_select" on decisions;
+drop policy if exists "decisions_owner_insert" on decisions;
+
+create policy "decisions_owner_select" on decisions
+  for select
   using (
     session_id in (
-      select id from sessions where user_id = auth.uid() or user_id is null
-    )
-  )
-  with check (
-    session_id in (
-      select id from sessions where user_id = auth.uid() or user_id is null
+      select id from sessions where user_id = auth.uid()
     )
   );
 
--- Enable Realtime so a Launch Review team watching a doc can see new
--- ledger entries appear live. Idempotent guard like migration 005.
+create policy "decisions_owner_insert" on decisions
+  for insert
+  with check (
+    session_id in (
+      select id from sessions where user_id = auth.uid()
+    )
+  );
+
+-- Enable Realtime so watching clients can see new ledger entries appear
+-- live. Idempotent guard like migration 005.
 do $$
 begin
   if not exists (

--- a/supabase/migrations/006_decision_ledger.sql
+++ b/supabase/migrations/006_decision_ledger.sql
@@ -1,0 +1,51 @@
+-- Decision ledger: append-only intent log attached to a doc. Shadow
+-- artifact alongside the document itself so a future reader can answer
+-- "who decided this, and what alternative was killed?" — something
+-- version history alone can't express.
+--
+-- The table is intentionally permissive about content (jsonb entry)
+-- because the UI is still exploratory. We'll tighten the schema once
+-- the affordances stabilize.
+
+create table if not exists decisions (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid references sessions(id) on delete cascade not null,
+  paragraph_anchor text,          -- optional heading or span identifier
+  entry jsonb not null,           -- { proposer, objector?, adopter?, alternative?, confidence?, rationale }
+  proposed_by text not null,      -- human username or agent name
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_decisions_session
+  on decisions(session_id, created_at);
+
+-- RLS: user owns decisions via session ownership, matching agent_tasks.
+alter table decisions enable row level security;
+
+drop policy if exists "decisions_owner_all" on decisions;
+create policy "decisions_owner_all" on decisions
+  for all
+  using (
+    session_id in (
+      select id from sessions where user_id = auth.uid() or user_id is null
+    )
+  )
+  with check (
+    session_id in (
+      select id from sessions where user_id = auth.uid() or user_id is null
+    )
+  );
+
+-- Enable Realtime so a Launch Review team watching a doc can see new
+-- ledger entries appear live. Idempotent guard like migration 005.
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'decisions'
+  ) then
+    alter publication supabase_realtime add table decisions;
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Seeds the decision-ledger concept from the multi-entity collab brainstorm (lens 2): an append-only "shadow doc" attached to a session that records *{proposer, objector, adopter, alternative, confidence, rationale}* per decision. Lets future readers answer "who decided this and what alternative was killed?" — something plain version history can't express.

### Shipped
- `supabase/migrations/006_decision_ledger.sql`:
  - `decisions(id, session_id, paragraph_anchor, entry jsonb, proposed_by, created_at)`
  - Owner RLS matching `agent_tasks`.
  - Idempotent `ADD TABLE` to `supabase_realtime` so watching clients see ledger entries live.
- `DecisionEntry` + `DecisionRecord` types in `src/types.ts` with a reference to the brainstorm.

### Not shipped (follow-ups)
- `session-store.ts` client CRUD.
- A "Why this change?" affordance on agent proposal cards.
- A rendered ledger timeline next to the doc.

Kept schema permissive (jsonb) while the UI is exploratory; we'll tighten once affordances stabilize.

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes
- [x] Migration is idempotent via guard block + `create table if not exists`

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
