### PR TITLE
feat(db): standing-objection primitive (migration + type)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,28 @@ export interface ChatMessageRecord {
   created_at: string
 }
 
+/**
+ * A standing objection — a dissenting voice that travels with the doc.
+ * See docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md
+ * (lens 2, "the dissent primitive"). Withdrawing sets `withdrawn_at`
+ * but never deletes the row; the historical record persists.
+ */
+export interface StandingObjectionRecord {
+  id: string
+  session_id: string
+  /** Human username or agent name. */
+  objector: string
+  /** The dissent in the objector's own words. */
+  subject: string
+  /** Longer rationale; nullable to match the Supabase row shape. */
+  rationale: string | null
+  /** Optional heading or span the objection attaches to. */
+  section_anchor: string | null
+  /** null = still standing; a timestamp = retracted (row persists). */
+  withdrawn_at: string | null
+  created_at: string
+}
+
 export interface SearchResult {
   title: string
   url: string

--- a/supabase/migrations/007_standing_objections.sql
+++ b/supabase/migrations/007_standing_objections.sql
@@ -10,8 +10,9 @@
 -- fact about this doc, not a comment buried in a thread.
 --
 -- UPDATE is allowed so an objector can retract (set withdrawn_at);
--- DELETE is not policied, so objections cannot be erased from the
--- record even after withdrawal.
+-- DELETE is not policed, so objections cannot be erased from the
+-- record even after withdrawal. A trigger below also pins
+-- session_id so an objection can't be moved between docs via UPDATE.
 
 create table if not exists standing_objections (
   id uuid primary key default gen_random_uuid(),
@@ -57,6 +58,28 @@ create policy "standing_objections_owner_update" on standing_objections
   with check (
     session_id in (select id from sessions where user_id = auth.uid())
   );
+
+-- Objections permanently attach to their original session/doc. The
+-- RLS WITH CHECK re-validates ownership but doesn't prevent moving a
+-- row between two sessions owned by the same user, so enforce it with
+-- a trigger.
+create or replace function prevent_standing_objections_session_change()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.session_id <> old.session_id then
+    raise exception 'standing_objections.session_id is immutable';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_prevent_standing_objections_session_change on standing_objections;
+create trigger trg_prevent_standing_objections_session_change
+  before update on standing_objections
+  for each row
+  execute function prevent_standing_objections_session_change();
 
 do $$
 begin

--- a/supabase/migrations/007_standing_objections.sql
+++ b/supabase/migrations/007_standing_objections.sql
@@ -59,11 +59,12 @@ create policy "standing_objections_owner_update" on standing_objections
     session_id in (select id from sessions where user_id = auth.uid())
   );
 
--- Objections permanently attach to their original session/doc. The
--- RLS WITH CHECK re-validates ownership but doesn't prevent moving a
--- row between two sessions owned by the same user, so enforce it with
--- a trigger.
-create or replace function prevent_standing_objections_session_change()
+-- Objections are historical record. The RLS WITH CHECK re-validates
+-- ownership but doesn't prevent moving a row between two sessions the
+-- user owns, nor rewriting objector/subject/etc. after the fact. The
+-- trigger below freezes every immutable field, leaving only
+-- `withdrawn_at` mutable (the sole legitimate update — retraction).
+create or replace function prevent_standing_objections_history_rewrite()
 returns trigger
 language plpgsql
 as $$
@@ -71,15 +72,33 @@ begin
   if new.session_id <> old.session_id then
     raise exception 'standing_objections.session_id is immutable';
   end if;
+  if new.objector is distinct from old.objector then
+    raise exception 'standing_objections.objector is immutable';
+  end if;
+  if new.subject is distinct from old.subject then
+    raise exception 'standing_objections.subject is immutable';
+  end if;
+  if new.rationale is distinct from old.rationale then
+    raise exception 'standing_objections.rationale is immutable';
+  end if;
+  if new.section_anchor is distinct from old.section_anchor then
+    raise exception 'standing_objections.section_anchor is immutable';
+  end if;
+  if new.created_at <> old.created_at then
+    raise exception 'standing_objections.created_at is immutable';
+  end if;
   return new;
 end;
 $$;
 
+-- Drop the older, narrower trigger name from an earlier commit on this
+-- branch so the migration is idempotent across reruns.
 drop trigger if exists trg_prevent_standing_objections_session_change on standing_objections;
-create trigger trg_prevent_standing_objections_session_change
+drop trigger if exists trg_prevent_standing_objections_history_rewrite on standing_objections;
+create trigger trg_prevent_standing_objections_history_rewrite
   before update on standing_objections
   for each row
-  execute function prevent_standing_objections_session_change();
+  execute function prevent_standing_objections_history_rewrite();
 
 do $$
 begin

--- a/supabase/migrations/007_standing_objections.sql
+++ b/supabase/migrations/007_standing_objections.sql
@@ -1,0 +1,71 @@
+-- Standing objections: a dissenting voice attached to a doc that
+-- travels with it forever. Borrowed from Quaker practice and IETF
+-- rough-consensus ("standing aside"). See
+-- docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md,
+-- lens 2 — "the dissent primitive".
+--
+-- Shipping as a first-class row rather than an attribute on chat
+-- messages so an objection is legible in its own right: "Maya
+-- standing-objects to the pricing model" should read as a structural
+-- fact about this doc, not a comment buried in a thread.
+--
+-- UPDATE is allowed so an objector can retract (set withdrawn_at);
+-- DELETE is not policied, so objections cannot be erased from the
+-- record even after withdrawal.
+
+create table if not exists standing_objections (
+  id uuid primary key default gen_random_uuid(),
+  session_id uuid references sessions(id) on delete cascade not null,
+  objector text not null,             -- human username or agent name
+  subject text not null,              -- what the objector is objecting to, in their own words
+  rationale text,                     -- optional longer reasoning
+  section_anchor text,                -- optional heading / span the objection attaches to
+  withdrawn_at timestamptz,           -- null = still standing; set to retract
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_standing_objections_session
+  on standing_objections(session_id, created_at);
+
+-- Ownership via session; strict (no "user_id is null" shortcut).
+alter table standing_objections enable row level security;
+
+drop policy if exists "standing_objections_owner_all" on standing_objections;
+drop policy if exists "standing_objections_owner_select" on standing_objections;
+drop policy if exists "standing_objections_owner_insert" on standing_objections;
+drop policy if exists "standing_objections_owner_update" on standing_objections;
+
+create policy "standing_objections_owner_select" on standing_objections
+  for select
+  using (
+    session_id in (select id from sessions where user_id = auth.uid())
+  );
+
+create policy "standing_objections_owner_insert" on standing_objections
+  for insert
+  with check (
+    session_id in (select id from sessions where user_id = auth.uid())
+  );
+
+-- UPDATE only, to support withdrawal. No DELETE policy — the record
+-- persists even after withdrawal.
+create policy "standing_objections_owner_update" on standing_objections
+  for update
+  using (
+    session_id in (select id from sessions where user_id = auth.uid())
+  )
+  with check (
+    session_id in (select id from sessions where user_id = auth.uid())
+  );
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'standing_objections'
+  ) then
+    alter publication supabase_realtime add table standing_objections;
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Seeds the "dissent primitive" from the multi-entity collab brainstorm: a standing objection is a first-class row that attaches a dissenter's name + reasoning to a doc and travels with it forever. Borrowed from Quaker practice and IETF rough-consensus ("standing aside").

### Shipped
- `supabase/migrations/007_standing_objections.sql`:
  - `standing_objections(id, session_id, objector, subject, rationale?, section_anchor?, withdrawn_at?, created_at)`
  - Strict session-ownership RLS (no `user_id is null` shortcut).
  - SELECT + INSERT + UPDATE policies only — no DELETE, so objections can't be erased even after withdrawal (`withdrawn_at` is set but the row persists).
  - Idempotent Realtime publication add.
- `StandingObjectionRecord` type in `src/types.ts`.

### Not shipped (follow-ups)
- `session-store.ts` client CRUD.
- UI affordance: standing-objection chip at the top of a doc, and an "I stand aside" option on any decision thread.

### Why split from the decision ledger

Both land as new tables for a reason: an objection is a *structural fact about the doc*, not a child of one decision entry. "Maya standing-objects to the pricing model" should read at the top of the PRD, even if the specific decision it objects to scrolls out of view.

## Test plan
- [x] `npm run build` succeeds
- [x] Migration is idempotent (guard block + `create table if not exists`)

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
