### PR TITLE
feat: MCP server scaffold (W3-T001)

### DIFF
--- a/api/mcp/[...route].ts
+++ b/api/mcp/[...route].ts
@@ -1,0 +1,162 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+
+export const maxDuration = 60
+
+/** Planned Wave 3 tools; each call returns a stub until W3-T003..T006 land */
+const STUB_TOOLS = [
+  {
+    name: 'doc.read',
+    description: 'Read current document content as Markdown (stub)',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'doc.edit',
+    description: 'Apply a Tiptap-compatible edit (stub)',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'doc.comment',
+    description: 'Add a comment to the document (stub)',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'session.list',
+    description: "List the user's sessions in a project (stub)",
+    inputSchema: { type: 'object', properties: {} },
+  },
+] as const
+
+type JsonRpcRequest = {
+  jsonrpc?: string
+  id?: string | number | null
+  method?: string
+  params?: Record<string, unknown>
+}
+
+function jsonRpcError(
+  id: string | number | null | undefined,
+  code: number,
+  message: string,
+) {
+  return {
+    jsonrpc: '2.0' as const,
+    id: id ?? null,
+    error: { code, message },
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v)
+}
+
+function parseBody(req: VercelRequest): unknown {
+  const raw = req.body
+  if (raw === undefined || raw === null) return undefined
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw) as unknown
+    } catch {
+      return undefined
+    }
+  }
+  return raw
+}
+
+function handleOne(message: unknown): unknown | null {
+  if (!isRecord(message)) {
+    return jsonRpcError(null, -32600, 'Invalid Request')
+  }
+
+  const { id, method } = message as JsonRpcRequest
+  const isNotification = id === undefined
+
+  if (typeof method !== 'string') {
+    return jsonRpcError(
+      isNotification ? null : id ?? null,
+      -32600,
+      'Invalid Request',
+    )
+  }
+
+  if (isNotification) {
+    if (method === 'notifications/initialized' || method === 'notifications/cancelled') {
+      return null
+    }
+    return null
+  }
+
+  const params = isRecord(message.params) ? message.params : {}
+
+  switch (method) {
+    case 'initialize':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          protocolVersion: '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'markup-mcp', version: '0.0.0' },
+        },
+      }
+    case 'tools/list':
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: { tools: [...STUB_TOOLS] },
+      }
+    case 'tools/call': {
+      const name = typeof params.name === 'string' ? params.name : ''
+      return {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: 'not implemented', tool: name }),
+            },
+          ],
+          isError: true,
+        },
+      }
+    }
+    case 'ping':
+      return { jsonrpc: '2.0', id, result: {} }
+    default:
+      return jsonRpcError(id ?? null, -32601, `Method not found: ${method}`)
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, Mcp-Session-Id')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end()
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS')
+    return res
+      .status(405)
+      .json(jsonRpcError(null, -32600, 'Method not allowed — use POST for MCP JSON-RPC'))
+  }
+
+  const parsed = parseBody(req)
+  if (parsed === undefined) {
+    return res.status(400).json(jsonRpcError(null, -32700, 'Parse error — expected JSON body'))
+  }
+
+  if (Array.isArray(parsed)) {
+    const out = parsed.map((m) => handleOne(m)).filter((x) => x !== null)
+    return res.status(200).json(out)
+  }
+
+  const single = handleOne(parsed)
+  if (single === null) {
+    return res.status(202).end()
+  }
+
+  return res.status(200).json(single)
+}


### PR DESCRIPTION
## What
- Add Vercel serverless handler at `api/mcp/[...route].ts` (POST JSON-RPC)
- Implements `initialize`, `tools/list`, `tools/call` (stub), `ping`; CORS for OPTIONS
- Every `tools/call` returns MCP text content with `{"error":"not implemented","tool":...}` and `isError: true`
- Lists planned tools: `doc.read`, `doc.edit`, `doc.comment`, `session.list`

## Why
`W3-T001` in `orchestration/plan.md` — MCP substrate for Quadrant C (parity with in-app agents).

## Acceptance
- [x] Vercel function path `api/mcp/[...route].ts` accepts POST and parses MCP-style JSON-RPC
- [x] Tool handlers stubbed (not implemented)

## Verification
```
npm run lint && npm run typecheck && npm test && npm run build
```
All passed locally.

## Risk
Low — new route only; no client or Supabase changes.

## Task
`W3-T001` in `orchestration/plan.md` (queue.json wave3 not populated yet)

**Note:** Orchestration log PR #245 (`orch-cursor` WAVE_3_START) can merge independently; this PR is based on current `main`.

cc @oliver — please dispatch Review Pool when CI is green.

**Manual check (author):** After Vercel preview deploys for this PR, add the preview URL + path `/api/mcp` (or `/api/mcp/`) as an MCP server in Cursor Settings and confirm `initialize` / `tools/list` succeed.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
