### PR TITLE
feat(types): TeamVolume dial alphabet + default

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,29 @@ export const DEFAULT_LIMITS: OrchestratorLimits = {
   reactionDelayMs: [3000, 5000],
 }
 
+/**
+ * Team volume dial — a shared per-doc setting that determines how
+ * loudly the active agents participate. See
+ * docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md
+ * (designer lens, #5 "Team volume dial").
+ *
+ *   silent   — agents only respond when @-mentioned
+ *   whisper  — margin suggestions only, no chat
+ *   discuss  — chat + suggestions, no direct edits
+ *   active   — agents edit freely in unclaimed regions
+ *
+ * Shipping the alphabet + default first so a follow-up can wire it to
+ * a header dial or settings without revisiting the naming.
+ */
+export type TeamVolume = 'silent' | 'whisper' | 'discuss' | 'active'
+export const DEFAULT_TEAM_VOLUME: TeamVolume = 'discuss'
+export const TEAM_VOLUME_LABELS: Record<TeamVolume, string> = {
+  silent: 'Silent',
+  whisper: 'Whisper',
+  discuss: 'Discuss',
+  active: 'Active',
+}
+
 export interface ExperimentSettings {
   autoActivateOnAdd: boolean
   insertStrategy: 'strict' | 'fuzzy' | 'always-end'


### PR DESCRIPTION
## Summary

Seeds the "team volume dial" from the multi-entity collab brainstorm (designer lens #5). Ships the alphabet + default + labels; no wiring.

```
silent   — agents only respond when @-mentioned
whisper  — margin suggestions only, no chat
discuss  — chat + suggestions, no direct edits  (default)
active   — agents edit freely in unclaimed regions
```

Follow-ups: a `volume` column on `sessions`, a header dial, per-agent mute overrides, and prompt-level enforcement in the orchestrator.

## Test plan
- [x] `npm run build` succeeds

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/248" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
