### PR TITLE
feat(types): AgentStance — declared lean + confidence

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,27 @@ export interface AgentState {
   inDoc: boolean
 }
 
+/**
+ * An agent's declared stance on the active disagreement in a doc. See
+ * docs/brainstorms/2026-04-19-multi-entity-collab-design-lenses.md
+ * (thought-leader lens #1, "Stance slots, not neutrality").
+ *
+ * The stance shipping model inverts the usual "agent as neutral
+ * analyst" framing: every agent must declare a stance when a live
+ * disagreement exists, rendered as a visible badge. Revocable (set
+ * `lean` to null to retract) but never absent.
+ *
+ *   lean       — which option the agent is leaning toward, or null
+ *   confidence — 0..1 self-assessed
+ *   note       — short sentence rendered under the badge on hover
+ */
+export interface AgentStance {
+  lean: string | null
+  confidence: number
+  note?: string
+  updatedAt: string
+}
+
 export interface TimelineEntry {
   id: string
   color: string


### PR DESCRIPTION
## Summary

Seeds the `AgentStance` type from the multi-entity collab brainstorm (thought-leader lens #1 "Stance slots, not neutrality"). Every agent in a live disagreement will eventually declare a stance — which option they lean toward, how confident they are — rather than performing neutral analysis.

```ts
interface AgentStance {
  lean: string | null    // option id, or null if retracted
  confidence: number     // 0..1
  note?: string
  updatedAt: string
}
```

Shipping the type first so follow-ups (stance badge next to the agent avatar, prompt-level requirement, ledger integration) can all consume the same shape.

## Test plan
- [x] `npm run build` succeeds

https://claude.ai/code/session_017JPWWxZMAV9KgV755kdUgK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/249" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
