### PR TITLE
feat: document_snapshots migration (W1-T002)

### DIFF
--- a/supabase/migrations/008_document_snapshots.sql
+++ b/supabase/migrations/008_document_snapshots.sql
@@ -1,0 +1,47 @@
+-- Document snapshots: append-only history of document content for the
+-- time-machine feature. A new row is created on each save so users can
+-- scrub back through document state. Content is the full Tiptap JSON
+-- blob; author is a free-form label ("user", "agent:aiden", etc.) so we
+-- don't have to join to auth.users for display.
+
+create table if not exists document_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  doc_id uuid not null references documents(id) on delete cascade,
+  content jsonb not null,
+  created_at timestamptz not null default now(),
+  author text not null default 'unknown'
+);
+
+create index if not exists document_snapshots_doc_id_created_at_idx
+  on document_snapshots (doc_id, created_at desc);
+
+alter table document_snapshots enable row level security;
+
+-- Snapshots scope via document → session ownership. Mirrors the
+-- pattern used for documents/chat_messages/agent_personas in 003.
+create policy "Users can read own document snapshots"
+  on document_snapshots for select
+  using (
+    doc_id in (
+      select id from documents
+      where session_id in (select id from sessions where user_id = auth.uid())
+    )
+  );
+
+create policy "Users can create own document snapshots"
+  on document_snapshots for insert
+  with check (
+    doc_id in (
+      select id from documents
+      where session_id in (select id from sessions where user_id = auth.uid())
+    )
+  );
+
+create policy "Users can delete own document snapshots"
+  on document_snapshots for delete
+  using (
+    doc_id in (
+      select id from documents
+      where session_id in (select id from sessions where user_id = auth.uid())
+    )
+  );


### PR DESCRIPTION
## Summary

- Add document_snapshots table migration

## Test plan

- [x] TypeScript check passes
- [x] Production build succeeds
- [x] All 407 tests pass (21 files)

*Processed by Gas Town Refinery*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
