### PR TITLE
feat: simultaneous-edit detector for LWW snapshot model (W1-T018)

### DIFF
--- a/src/__tests__/conflict-detector.test.ts
+++ b/src/__tests__/conflict-detector.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  noteRemoteEdit,
+  isSimultaneousEdit,
+  getLastRemoteEditAt,
+  clearRemoteEditHistory,
+  _resetConflictDetector,
+  SIMULTANEOUS_EDIT_WINDOW_MS,
+} from '../lib/conflict-detector'
+
+beforeEach(() => {
+  _resetConflictDetector()
+})
+
+describe('noteRemoteEdit / getLastRemoteEditAt', () => {
+  it('records and returns the most recent remote-edit timestamp per session', () => {
+    noteRemoteEdit('s1', 1000)
+    noteRemoteEdit('s2', 2000)
+    expect(getLastRemoteEditAt('s1')).toBe(1000)
+    expect(getLastRemoteEditAt('s2')).toBe(2000)
+  })
+
+  it('overwrites the previous timestamp on a later note', () => {
+    noteRemoteEdit('s1', 1000)
+    noteRemoteEdit('s1', 1500)
+    expect(getLastRemoteEditAt('s1')).toBe(1500)
+  })
+
+  it('returns undefined for an unseen session', () => {
+    expect(getLastRemoteEditAt('never-seen')).toBeUndefined()
+  })
+
+  it('defaults the timestamp to Date.now()', () => {
+    const before = Date.now()
+    noteRemoteEdit('s1')
+    const after = Date.now()
+    const recorded = getLastRemoteEditAt('s1')
+    expect(recorded).toBeDefined()
+    expect(recorded!).toBeGreaterThanOrEqual(before)
+    expect(recorded!).toBeLessThanOrEqual(after)
+  })
+})
+
+describe('isSimultaneousEdit', () => {
+  it('returns false when no remote edit has been recorded', () => {
+    expect(isSimultaneousEdit('s1', 1000)).toBe(false)
+  })
+
+  it('returns true when a remote edit landed strictly inside the window', () => {
+    noteRemoteEdit('s1', 1000)
+    // 1.5s later — well inside the 2s window
+    expect(isSimultaneousEdit('s1', 2500)).toBe(true)
+  })
+
+  it('returns true at the moment the remote edit arrived', () => {
+    noteRemoteEdit('s1', 1000)
+    expect(isSimultaneousEdit('s1', 1000)).toBe(true)
+  })
+
+  it('returns false at the exact window boundary (window is exclusive)', () => {
+    noteRemoteEdit('s1', 1000)
+    expect(isSimultaneousEdit('s1', 1000 + SIMULTANEOUS_EDIT_WINDOW_MS)).toBe(false)
+  })
+
+  it('returns false once the window has elapsed', () => {
+    noteRemoteEdit('s1', 1000)
+    expect(isSimultaneousEdit('s1', 5000)).toBe(false)
+  })
+
+  it('honors a caller-supplied window override', () => {
+    noteRemoteEdit('s1', 1000)
+    expect(isSimultaneousEdit('s1', 1500, 400)).toBe(false)
+    expect(isSimultaneousEdit('s1', 1300, 400)).toBe(true)
+  })
+
+  it('isolates state per session id', () => {
+    noteRemoteEdit('s1', 1000)
+    expect(isSimultaneousEdit('s2', 1500)).toBe(false)
+  })
+})
+
+describe('clearRemoteEditHistory', () => {
+  it('drops the recorded timestamp so subsequent checks return false', () => {
+    noteRemoteEdit('s1', 1000)
+    clearRemoteEditHistory('s1')
+    expect(getLastRemoteEditAt('s1')).toBeUndefined()
+    expect(isSimultaneousEdit('s1', 1500)).toBe(false)
+  })
+
+  it('only clears the named session', () => {
+    noteRemoteEdit('s1', 1000)
+    noteRemoteEdit('s2', 1000)
+    clearRemoteEditHistory('s1')
+    expect(getLastRemoteEditAt('s1')).toBeUndefined()
+    expect(getLastRemoteEditAt('s2')).toBe(1000)
+  })
+
+  it('no-ops on an unknown session id', () => {
+    expect(() => clearRemoteEditHistory('never-seen')).not.toThrow()
+  })
+})
+
+describe('SIMULTANEOUS_EDIT_WINDOW_MS', () => {
+  it('matches the W1-T018 spec of 2 seconds', () => {
+    expect(SIMULTANEOUS_EDIT_WINDOW_MS).toBe(2000)
+  })
+})

--- a/src/lib/conflict-detector.ts
+++ b/src/lib/conflict-detector.ts
@@ -1,0 +1,75 @@
+/**
+ * Simultaneous-edit detector for the snapshot-based document model.
+ *
+ * Conflict-resolution strategy in this codebase is **last-write-wins per
+ * document node** (the document is the node — see `documents.html_snapshot`
+ * in `supabase/migrations/001_initial_schema.sql`). The Supabase upsert in
+ * `saveDocument` overwrites the row unconditionally, so the most recent
+ * `saveDocument` call across all clients silently becomes the durable
+ * truth. That keeps the data path simple but loses one client's edits when
+ * two authors type at the same time.
+ *
+ * This module gives the UI a hook to warn when that happens. Callers note
+ * incoming remote edits via `noteRemoteEdit(sessionId)` and then ask
+ * `isSimultaneousEdit(sessionId)` right before persisting a local edit.
+ * If a remote edit landed inside the warning window (default 2s), the
+ * caller should surface a toast so the user knows their save likely
+ * stomped a teammate's keystrokes.
+ *
+ * The module is intentionally side-effect free: no toasts, no React, no
+ * Supabase. UI wiring happens in the editor hook and downstream tasks
+ * (W1-T019 out-of-sync indicator, W1-T020 multi-author).
+ */
+
+const lastRemoteEditAt = new Map<string, number>()
+
+/** Default warning window. Per spec W1-T018: warn on simultaneous edit within 2s. */
+export const SIMULTANEOUS_EDIT_WINDOW_MS = 2000
+
+/**
+ * Record that a remote edit for `sessionId` has just been observed.
+ * Call from the realtime subscriber when a doc-edit broadcast or a
+ * `postgres_changes` row lands and is not equal to the local snapshot.
+ */
+export function noteRemoteEdit(sessionId: string, nowMs: number = Date.now()): void {
+  lastRemoteEditAt.set(sessionId, nowMs)
+}
+
+/**
+ * True when a remote edit for `sessionId` landed within `windowMs` of
+ * `nowMs`. Read this just before saving a local edit; if it returns true
+ * the caller should warn the user that their save raced an incoming edit
+ * and likely overwrote it.
+ */
+export function isSimultaneousEdit(
+  sessionId: string,
+  nowMs: number = Date.now(),
+  windowMs: number = SIMULTANEOUS_EDIT_WINDOW_MS,
+): boolean {
+  const last = lastRemoteEditAt.get(sessionId)
+  if (last === undefined) return false
+  return nowMs - last < windowMs
+}
+
+/**
+ * Read-only accessor for the most recently observed remote-edit timestamp
+ * for `sessionId`, or `undefined` if none has been recorded. Useful for
+ * tests and for downstream out-of-sync indicators (W1-T019).
+ */
+export function getLastRemoteEditAt(sessionId: string): number | undefined {
+  return lastRemoteEditAt.get(sessionId)
+}
+
+/**
+ * Forget any remote-edit history for `sessionId`. Call on session switch
+ * or unmount so a stale timestamp from a previous session can't trigger a
+ * spurious warning in the next one.
+ */
+export function clearRemoteEditHistory(sessionId: string): void {
+  lastRemoteEditAt.delete(sessionId)
+}
+
+/** Test-only: drop all tracked sessions. */
+export function _resetConflictDetector(): void {
+  lastRemoteEditAt.clear()
+}


### PR DESCRIPTION
## Summary

- Add simultaneous-edit detector for last-write-wins snapshot model

## Test plan

- [x] TypeScript check passes
- [x] Production build succeeds
- [x] All 422 tests pass (22 files)

*Processed by Gas Town Refinery*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
