### PR TITLE
feat(auth): Supabase auth foundation — email/pw, GitHub OAuth, password reset, RLS fix (mk-u3v)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2434,6 +2434,218 @@
   font-size: 13px;
 }
 
+/* Email/password login form */
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 32px;
+  padding: 24px;
+  width: 100%;
+  max-width: 400px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  backdrop-filter: blur(12px);
+  animation: headlineIn 0.8s var(--ease-out-expo) 0.4s both;
+}
+
+.login-form-title {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  font-family: var(--font-ui);
+}
+
+.login-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.login-field-label {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  font-family: var(--font-ui);
+}
+
+.login-input {
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: var(--font-ui);
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color var(--duration-fast) ease, background var(--duration-fast) ease;
+}
+
+.login-input:focus {
+  border-color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.login-input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.login-error {
+  padding: 8px 12px;
+  font-size: 13px;
+  color: #ffb4a6;
+  background: rgba(255, 80, 60, 0.15);
+  border: 1px solid rgba(255, 80, 60, 0.35);
+  border-radius: var(--radius-sm);
+}
+
+.login-notice {
+  padding: 8px 12px;
+  font-size: 13px;
+  color: #b8f2c4;
+  background: rgba(48, 209, 88, 0.15);
+  border: 1px solid rgba(48, 209, 88, 0.35);
+  border-radius: var(--radius-sm);
+}
+
+.login-submit {
+  margin-top: 4px;
+}
+
+.login-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.login-links {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.login-link {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: var(--font-ui);
+}
+
+.login-link:hover {
+  color: #fff;
+}
+
+.login-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0 4px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.login-divider::before,
+.login-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.login-oauth-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.login-oauth-row .login-google-btn {
+  justify-content: center;
+  width: 100%;
+}
+
+/* Update password modal (password recovery flow) */
+.update-password-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.update-password-modal {
+  width: 100%;
+  max-width: 380px;
+  padding: 24px;
+  background: var(--surface-0);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.update-password-title {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+}
+
+.update-password-desc {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.update-password-modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.update-password-modal .login-field-label {
+  color: var(--text-secondary);
+}
+
+.update-password-modal .login-input {
+  color: var(--text-primary);
+  background: var(--surface-1);
+  border: 1px solid var(--border-default);
+}
+
+.update-password-modal .login-input:focus {
+  border-color: var(--text-tertiary);
+  background: var(--surface-0);
+}
+
+.update-password-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 4px;
+}
+
+.update-password-actions .login-link {
+  color: var(--text-secondary);
+}
+
+.update-password-actions .login-link:hover {
+  color: var(--text-primary);
+}
+
 /* Agent blob showcase on login page */
 .home-blobs-section {
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ const TemplatePickerModal = lazy(() => import('./TemplatePickerModal').then(m =>
 import type { GoogleDocFile } from './TemplatePickerModal'
 const ExperimentControls = lazy(() => import('./ExperimentControls').then(m => ({ default: m.ExperimentControls })))
 const KeyboardShortcutsModal = lazy(() => import('./components/KeyboardShortcutsModal').then(m => ({ default: m.KeyboardShortcutsModal })))
+const UpdatePasswordModal = lazy(() => import('./components/UpdatePasswordModal').then(m => ({ default: m.UpdatePasswordModal })))
 import { updateSessionTitle, saveChatMessage, saveAgentTasks, updateAgentTask, subscribeToDocument, subscribeToPresence, loadProjects } from './lib/session-store'
 import { identify, events } from './lib/analytics'
 import { TamboProvider } from '@tambo-ai/react'
@@ -56,7 +57,7 @@ const DOC_SAVE_DEBOUNCE_MS = 2000
 const DOC_EDIT_REACT_DEBOUNCE_MS = 3000
 
 function App() {
-  const { user, loading: authLoading, signOut, providerToken, signInWithGoogle } = useAuth()
+  const { user, loading: authLoading, signOut, providerToken, signInWithGoogle, recovering, clearRecovering } = useAuth()
   const { toast } = useToast()
 
   // Read-only spectator mode: /s/:id?view=1 — doc is not editable and
@@ -670,6 +671,11 @@ function App() {
       {showShortcutsHelp && (
         <Suspense>
           <KeyboardShortcutsModal onClose={() => setShowShortcutsHelp(false)} />
+        </Suspense>
+      )}
+      {recovering && (
+        <Suspense>
+          <UpdatePasswordModal onClose={clearRecovering} />
         </Suspense>
       )}
       <Celebration

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -1,10 +1,61 @@
-import { lazy, Suspense } from 'react'
+import { lazy, Suspense, useState, type FormEvent } from 'react'
 const ColorPanels = lazy(() => import('@paper-design/shaders-react').then(m => ({ default: m.ColorPanels })))
 import { MarkupLogo } from './MarkupLogo'
 import { useAuth } from './lib/auth-context'
 
+type Mode = 'signin' | 'signup' | 'reset'
+
 export function LoginPage() {
-  const { signInWithGoogle } = useAuth()
+  const {
+    signInWithGoogle,
+    signInWithGitHub,
+    signInWithEmail,
+    signUpWithEmail,
+    resetPassword,
+  } = useAuth()
+
+  const [mode, setMode] = useState<Mode>('signin')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const resetStatus = () => {
+    setError(null)
+    setNotice(null)
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    resetStatus()
+    setBusy(true)
+    try {
+      if (mode === 'signin') {
+        const { error } = await signInWithEmail(email.trim(), password)
+        if (error) setError(error)
+      } else if (mode === 'signup') {
+        const { error } = await signUpWithEmail(email.trim(), password, displayName.trim() || undefined)
+        if (error) setError(error)
+        else setNotice('Check your email to verify your account.')
+      } else {
+        const { error } = await resetPassword(email.trim())
+        if (error) setError(error)
+        else setNotice('Password reset link sent. Check your email.')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const switchMode = (next: Mode) => {
+    resetStatus()
+    setMode(next)
+  }
+
+  const title = mode === 'signup' ? 'Create account' : mode === 'reset' ? 'Reset password' : 'Sign in'
+  const submitLabel = mode === 'signup' ? 'Create account' : mode === 'reset' ? 'Send reset link' : 'Sign in'
 
   return (
     <div className="login-page">
@@ -21,7 +72,7 @@ export function LoginPage() {
           </div>
           <div className="home-nav-actions">
             <button type="button" className="login-google-btn login-google-btn--nav" onClick={signInWithGoogle}>
-              Sign in
+              Sign in with Google
             </button>
           </div>
         </nav>
@@ -34,11 +85,94 @@ export function LoginPage() {
           <p className="login-subtitle">
             AI agents that read your docs and push back on what you missed.
           </p>
-          <div className="login-cta-row">
-            <button type="button" className="home-cta-primary" onClick={signInWithGoogle}>
-              Get started
+
+          <form className="login-form" onSubmit={handleSubmit} aria-label={title}>
+            <h2 className="login-form-title">{title}</h2>
+
+            {mode === 'signup' && (
+              <label className="login-field">
+                <span className="login-field-label">Display name</span>
+                <input
+                  type="text"
+                  className="login-input"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  autoComplete="name"
+                  placeholder="Your name"
+                />
+              </label>
+            )}
+
+            <label className="login-field">
+              <span className="login-field-label">Email</span>
+              <input
+                type="email"
+                className="login-input"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                autoComplete="email"
+                required
+                placeholder="you@example.com"
+              />
+            </label>
+
+            {mode !== 'reset' && (
+              <label className="login-field">
+                <span className="login-field-label">Password</span>
+                <input
+                  type="password"
+                  className="login-input"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
+                  required
+                  minLength={8}
+                  placeholder={mode === 'signup' ? 'At least 8 characters' : 'Your password'}
+                />
+              </label>
+            )}
+
+            {error && <div className="login-error" role="alert">{error}</div>}
+            {notice && <div className="login-notice" role="status">{notice}</div>}
+
+            <button type="submit" className="home-cta-primary login-submit" disabled={busy}>
+              {busy ? 'Working…' : submitLabel}
             </button>
-          </div>
+
+            <div className="login-links">
+              {mode === 'signin' && (
+                <>
+                  <button type="button" className="login-link" onClick={() => switchMode('reset')}>
+                    Forgot password?
+                  </button>
+                  <button type="button" className="login-link" onClick={() => switchMode('signup')}>
+                    Create account
+                  </button>
+                </>
+              )}
+              {mode === 'signup' && (
+                <button type="button" className="login-link" onClick={() => switchMode('signin')}>
+                  Have an account? Sign in
+                </button>
+              )}
+              {mode === 'reset' && (
+                <button type="button" className="login-link" onClick={() => switchMode('signin')}>
+                  Back to sign in
+                </button>
+              )}
+            </div>
+
+            <div className="login-divider"><span>or</span></div>
+
+            <div className="login-oauth-row">
+              <button type="button" className="login-google-btn" onClick={signInWithGoogle}>
+                Continue with Google
+              </button>
+              <button type="button" className="login-google-btn" onClick={signInWithGitHub}>
+                Continue with GitHub
+              </button>
+            </div>
+          </form>
         </header>
 
         <footer className="login-footer">

--- a/src/components/UpdatePasswordModal.tsx
+++ b/src/components/UpdatePasswordModal.tsx
@@ -1,0 +1,78 @@
+import { useState, type FormEvent } from 'react'
+import { useAuth } from '../lib/auth-context'
+
+export function UpdatePasswordModal({ onClose }: { onClose: () => void }) {
+  const { updatePassword } = useAuth()
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [done, setDone] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters.')
+      return
+    }
+    if (password !== confirm) {
+      setError('Passwords do not match.')
+      return
+    }
+    setBusy(true)
+    const { error } = await updatePassword(password)
+    setBusy(false)
+    if (error) setError(error)
+    else setDone(true)
+  }
+
+  return (
+    <div className="update-password-backdrop" role="dialog" aria-modal="true" aria-label="Update password">
+      <div className="update-password-modal">
+        <h2 className="update-password-title">Set a new password</h2>
+        {done ? (
+          <>
+            <p className="update-password-desc">Password updated. You&apos;re signed in.</p>
+            <button type="button" className="home-cta-primary" onClick={onClose}>Continue</button>
+          </>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <label className="login-field">
+              <span className="login-field-label">New password</span>
+              <input
+                type="password"
+                className="login-input"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="new-password"
+                required
+                minLength={8}
+                autoFocus
+              />
+            </label>
+            <label className="login-field">
+              <span className="login-field-label">Confirm password</span>
+              <input
+                type="password"
+                className="login-input"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                autoComplete="new-password"
+                required
+                minLength={8}
+              />
+            </label>
+            {error && <div className="login-error" role="alert">{error}</div>}
+            <div className="update-password-actions">
+              <button type="button" className="login-link" onClick={onClose}>Cancel</button>
+              <button type="submit" className="home-cta-primary" disabled={busy}>
+                {busy ? 'Updating…' : 'Update password'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/auth-context.ts
+++ b/src/lib/auth-context.ts
@@ -1,20 +1,42 @@
 import { createContext, useContext } from 'react'
-import type { User } from '@supabase/supabase-js'
+import type { Session, User } from '@supabase/supabase-js'
+
+export type AuthResult = { error: string | null }
 
 export interface AuthContextValue {
   user: User | null
+  session: Session | null
   loading: boolean
+  recovering: boolean
+  clearRecovering: () => void
   providerToken: string | null
   signInWithGoogle: () => Promise<void>
+  signInWithGitHub: () => Promise<void>
+  signInWithEmail: (email: string, password: string) => Promise<AuthResult>
+  signUpWithEmail: (email: string, password: string, displayName?: string) => Promise<AuthResult>
+  resetPassword: (email: string) => Promise<AuthResult>
+  updatePassword: (newPassword: string) => Promise<AuthResult>
+  updateProfile: (data: { displayName?: string; avatarUrl?: string }) => Promise<AuthResult>
   signOut: () => Promise<void>
+  signOutEverywhere: () => Promise<void>
 }
 
 export const AuthContext = createContext<AuthContextValue>({
   user: null,
+  session: null,
   loading: true,
+  recovering: false,
+  clearRecovering: () => {},
   providerToken: null,
   signInWithGoogle: async () => {},
+  signInWithGitHub: async () => {},
+  signInWithEmail: async () => ({ error: 'AuthProvider not mounted' }),
+  signUpWithEmail: async () => ({ error: 'AuthProvider not mounted' }),
+  resetPassword: async () => ({ error: 'AuthProvider not mounted' }),
+  updatePassword: async () => ({ error: 'AuthProvider not mounted' }),
+  updateProfile: async () => ({ error: 'AuthProvider not mounted' }),
   signOut: async () => {},
+  signOutEverywhere: async () => {},
 })
 
 export function useAuth() {

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,30 +1,43 @@
 import { useEffect, useState } from 'react'
 import { supabase } from './supabase'
-import type { User } from '@supabase/supabase-js'
-import { AuthContext } from './auth-context'
+import type { Session, User } from '@supabase/supabase-js'
+import { AuthContext, type AuthResult } from './auth-context'
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  return 'Unknown error'
+}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
+  const [session, setSession] = useState<Session | null>(null)
   const [loading, setLoading] = useState(true)
+  const [recovering, setRecovering] = useState(false)
   const [providerToken, setProviderToken] = useState<string | null>(null)
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
       setUser(session?.user ?? null)
       setProviderToken(session?.provider_token ?? null)
       setLoading(false)
     })
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (_event, session) => {
+      (event, session) => {
+        setSession(session)
         setUser(session?.user ?? null)
         setProviderToken(session?.provider_token ?? null)
         setLoading(false)
+        if (event === 'PASSWORD_RECOVERY') setRecovering(true)
       },
     )
 
     return () => subscription.unsubscribe()
   }, [])
+
+  const clearRecovering = () => setRecovering(false)
 
   const signInWithGoogle = async () => {
     await supabase.auth.signInWithOAuth({
@@ -36,12 +49,88 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     })
   }
 
+  const signInWithGitHub = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'github',
+      options: { redirectTo: window.location.origin },
+    })
+  }
+
+  const signInWithEmail = async (email: string, password: string): Promise<AuthResult> => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    return { error: error ? formatError(error) : null }
+  }
+
+  const signUpWithEmail = async (
+    email: string,
+    password: string,
+    displayName?: string,
+  ): Promise<AuthResult> => {
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: window.location.origin,
+        data: displayName ? { full_name: displayName, name: displayName } : undefined,
+      },
+    })
+    return { error: error ? formatError(error) : null }
+  }
+
+  const resetPassword = async (email: string): Promise<AuthResult> => {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}?reset=1`,
+    })
+    return { error: error ? formatError(error) : null }
+  }
+
+  const updatePassword = async (newPassword: string): Promise<AuthResult> => {
+    const { error } = await supabase.auth.updateUser({ password: newPassword })
+    return { error: error ? formatError(error) : null }
+  }
+
+  const updateProfile = async (data: {
+    displayName?: string
+    avatarUrl?: string
+  }): Promise<AuthResult> => {
+    const metadata: Record<string, string> = {}
+    if (data.displayName) {
+      metadata.full_name = data.displayName
+      metadata.name = data.displayName
+    }
+    if (data.avatarUrl) metadata.avatar_url = data.avatarUrl
+    const { error } = await supabase.auth.updateUser({ data: metadata })
+    return { error: error ? formatError(error) : null }
+  }
+
   const signOut = async () => {
     await supabase.auth.signOut()
   }
 
+  const signOutEverywhere = async () => {
+    await supabase.auth.signOut({ scope: 'global' })
+  }
+
   return (
-    <AuthContext.Provider value={{ user, loading, providerToken, signInWithGoogle, signOut }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        session,
+        loading,
+        recovering,
+        clearRecovering,
+        providerToken,
+        signInWithGoogle,
+        signInWithGitHub,
+        signInWithEmail,
+        signUpWithEmail,
+        resetPassword,
+        updatePassword,
+        updateProfile,
+        signOut,
+        signOutEverywhere,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   )

--- a/supabase/migrations/011_auth_rls_consolidation.sql
+++ b/supabase/migrations/011_auth_rls_consolidation.sql
@@ -1,0 +1,5 @@
+-- Tighten RLS gaps left by prior migrations.
+-- 004_agent_tasks.sql shipped with a permissive "Allow all for anon" policy
+-- that grants any caller (including anon) full access to agent_tasks, nullifying
+-- the owner-scoped policy on the same table. Drop it so only the owner policy applies.
+drop policy if exists "Allow all for anon" on agent_tasks;


### PR DESCRIPTION
## Summary
- Extends existing Google-OAuth-only auth with email/password sign-in+sign-up, GitHub OAuth, forgot-password email flow, in-app password update (on PASSWORD_RECOVERY event), profile updates, and sign-out-everywhere
- Adds \`UpdatePasswordModal\` shown when Supabase fires \`PASSWORD_RECOVERY\`
- Migration 011: drops \`agent_tasks\` permissive "Allow all for anon" policy that nullified owner RLS (security fix)

Closes mk-u3v.

## Test plan
- [ ] Email/password signup flow: verify email received, account created
- [ ] Email/password sign-in works
- [ ] Google OAuth still works (regression)
- [ ] GitHub OAuth works (configure provider in Supabase dashboard if not already)
- [ ] Forgot password → email arrives → recovery link opens app → UpdatePasswordModal shown → new password works
- [ ] Sign-out-everywhere ends other browser sessions
- [ ] After migration 011: anon callers cannot SELECT from agent_tasks; authed owner can
- [ ] \`npm run build\`, \`typecheck\`, \`lint\` pass

## Known / deferred
- MFA/TOTP not in scope (separate bead)
- Magic links not added (not trivial in current flow)
- 1 pre-existing test failure in \`session-store-projects.test.ts\` (from W1-T003, unrelated) — will file follow-up

## Dashboard config required
- Supabase → Authentication → Providers: enable GitHub, add callback URL
- Auth → Email Templates: confirm email template uses \`{{ .ConfirmationURL }}\`
- Auth → URL Configuration: redirect URLs include localhost + prod origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
