### PR TITLE
fix: align loadProjects error test with graceful fallback (mk-8a4)

### DIFF
--- a/src/__tests__/session-store-projects.test.ts
+++ b/src/__tests__/session-store-projects.test.ts
@@ -117,9 +117,19 @@ describe('loadProjects', () => {
     expect(result).toEqual([])
   })
 
-  it('throws when supabase returns an error', async () => {
+  it('returns [] and warns when supabase returns an error', async () => {
     nextResults['projects'] = { data: null, error: new Error('rls denied') }
-    await expect(loadProjects()).rejects.toThrow('rls denied')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const result = await loadProjects()
+      expect(result).toEqual([])
+      expect(warn).toHaveBeenCalledWith(
+        'loadProjects failed, falling back to empty:',
+        'rls denied',
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- Fixes the pre-existing failing test `session-store-projects.test.ts > loadProjects > 'throws when supabase returns an error'` that shipped broken in PR #260
- Test now matches the actual graceful-fallback behavior of loadProjects

Closes mk-8a4.

## Test plan
- [x] `npm run test` passes (was 1 failed / 504 passed; now 505 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
