### PR TITLE
fix(auth): address Copilot review items 1-4 from PR#270 (mk-2ik)

### DIFF
--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -3,6 +3,12 @@ const ColorPanels = lazy(() => import('@paper-design/shaders-react').then(m => (
 import { MarkupLogo } from './MarkupLogo'
 import { useAuth } from './lib/auth-context'
 
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === 'string') return err
+  return 'Unknown error'
+}
+
 type Mode = 'signin' | 'signup' | 'reset'
 
 export function LoginPage() {
@@ -44,6 +50,8 @@ export function LoginPage() {
         if (error) setError(error)
         else setNotice('Password reset link sent. Check your email.')
       }
+    } catch (err) {
+      setError(formatError(err))
     } finally {
       setBusy(false)
     }

--- a/src/components/UpdatePasswordModal.tsx
+++ b/src/components/UpdatePasswordModal.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useEffect, useState, type FormEvent, type MouseEvent } from 'react'
 import { useAuth } from '../lib/auth-context'
 
 export function UpdatePasswordModal({ onClose }: { onClose: () => void }) {
@@ -8,6 +8,18 @@ export function UpdatePasswordModal({ onClose }: { onClose: () => void }) {
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const handleBackdropClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose()
+  }
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -28,8 +40,13 @@ export function UpdatePasswordModal({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <div className="update-password-backdrop" role="dialog" aria-modal="true" aria-label="Update password">
-      <div className="update-password-modal">
+    <div className="update-password-backdrop" onClick={handleBackdropClick}>
+      <div
+        className="update-password-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Update password"
+      >
         <h2 className="update-password-title">Set a new password</h2>
         {done ? (
           <>

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -79,7 +79,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const resetPassword = async (email: string): Promise<AuthResult> => {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}?reset=1`,
+      redirectTo: window.location.origin,
     })
     return { error: error ? formatError(error) : null }
   }
@@ -99,6 +99,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       metadata.name = data.displayName
     }
     if (data.avatarUrl) metadata.avatar_url = data.avatarUrl
+    if (Object.keys(metadata).length === 0) return { error: null }
     const { error } = await supabase.auth.updateUser({ data: metadata })
     return { error: error ? formatError(error) : null }
   }


### PR DESCRIPTION
## Summary
Addresses 4 of 5 Copilot review comments on PR #270:

- **Item 1** — `LoginPage.handleSubmit` now catches exceptions and surfaces via `formatError` instead of letting them bubble
- **Item 2** — `UpdatePasswordModal`: `role='dialog'`/`aria-modal` moved from backdrop to dialog panel; added Escape + click-outside to close (consistent with TemplatePicker/CommandPalette)
- **Item 3** — Removed unused `?reset=1` query param from `resetPasswordForEmail` redirectTo
- **Item 4** — `updateProfile` now no-ops when metadata is empty

Partial for mk-2ik; the two remaining follow-ups (Copilot item 5 regression test + Supabase Preview investigation) are tracked separately.

## Test plan
- [ ] Trigger an auth exception (e.g. offline) → error renders in form
- [ ] Open UpdatePasswordModal → press Esc closes; click outside closes
- [ ] Forgot password flow: reset URL no longer has `?reset=1`
- [ ] updateProfile with `{}` makes no network call
- [ ] `npm run build`, `typecheck`, `lint`, `test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
