### PR TITLE
feat: referral system — codes, attribution, dashboard (mk-rsd)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3763,6 +3763,8 @@
   color: var(--text-primary);
 }
 
+a.sidebar-avatar-menu-item { text-decoration: none; }
+
 .sidebar-user {
   border-top: 1px solid var(--border-subtle);
   padding: 10px 12px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { loadUserSettings, saveGeminiApiKey } from './lib/settings-store'
 // Lazy-loaded components (not needed on initial render)
 const LoginPage = lazy(() => import('./LoginPage').then(m => ({ default: m.LoginPage })))
 const LegalPage = lazy(() => import('./LegalPage').then(m => ({ default: m.LegalPage })))
+const ReferralsPage = lazy(() => import('./ReferralsPage').then(m => ({ default: m.ReferralsPage })))
 const TemplatePickerModal = lazy(() => import('./TemplatePickerModal').then(m => ({ default: m.TemplatePickerModal })))
 import type { GoogleDocFile } from './TemplatePickerModal'
 const ExperimentControls = lazy(() => import('./ExperimentControls').then(m => ({ default: m.ExperimentControls })))
@@ -14,6 +15,7 @@ const KeyboardShortcutsModal = lazy(() => import('./components/KeyboardShortcuts
 const UpdatePasswordModal = lazy(() => import('./components/UpdatePasswordModal').then(m => ({ default: m.UpdatePasswordModal })))
 import { updateSessionTitle, saveChatMessage, saveAgentTasks, updateAgentTask, subscribeToDocument, subscribeToPresence, loadProjects } from './lib/session-store'
 import { identify, events } from './lib/analytics'
+import { claimReferralCode, PENDING_REF_STORAGE_KEY, readRefParam } from './lib/referrals'
 import { TamboProvider } from '@tambo-ai/react'
 import { tamboComponents } from './lib/tambo'
 import { useAuth } from './lib/auth-context'
@@ -74,6 +76,31 @@ function App() {
   // PostHog user identification (init handled by PostHogProvider in main.tsx)
   useEffect(() => {
     if (user) identify(user.id, { email: user.email })
+  }, [user])
+
+  // Referral attribution. Capture ?ref=CODE at first render and stash it
+  // so it survives the OAuth redirect + email-verify round trip. Once a
+  // user is signed in, fire the claim RPC (silent on validation misses)
+  // and strip the param from the URL so the code isn't re-claimed on
+  // refresh.
+  useEffect(() => {
+    const code = readRefParam()
+    if (code) {
+      try { localStorage.setItem(PENDING_REF_STORAGE_KEY, code) } catch { /* storage disabled */ }
+      const url = new URL(window.location.href)
+      url.searchParams.delete('ref')
+      window.history.replaceState({}, '', url.toString())
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!user) return
+    let pending: string | null = null
+    try { pending = localStorage.getItem(PENDING_REF_STORAGE_KEY) } catch { /* storage disabled */ }
+    if (!pending) return
+    claimReferralCode(pending).finally(() => {
+      try { localStorage.removeItem(PENDING_REF_STORAGE_KEY) } catch { /* storage disabled */ }
+    })
   }, [user])
 
   const [showTemplatePicker, setShowTemplatePicker] = useState(false)
@@ -441,6 +468,13 @@ function App() {
   // Legal pages -- accessible without auth
   if (window.location.pathname === '/privacy') return <Suspense><LegalPage page="privacy" /></Suspense>
   if (window.location.pathname === '/terms') return <Suspense><LegalPage page="terms" /></Suspense>
+
+  // Referrals page -- requires a signed-in user (or localhost).
+  // Uses full-page nav on close to match the legal-pages pattern so the
+  // app re-renders cleanly without a router.
+  if (window.location.pathname === '/referrals' && (user || isLocalhost)) {
+    return <Suspense><ReferralsPage onClose={() => { window.location.href = '/' }} /></Suspense>
+  }
 
   // Share link recipient view -- accessible without auth (viewer role);
   // commenter/editor roles still render the view but rely on the user

--- a/src/ReferralsPage.tsx
+++ b/src/ReferralsPage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react'
+import { buildReferralLink, listMyReferrals, loadMyProfile, type Profile, type Referral } from './lib/referrals'
+
+interface Props {
+  onClose: () => void
+}
+
+export function ReferralsPage({ onClose }: Props) {
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [referrals, setReferrals] = useState<Referral[]>([])
+  const [loading, setLoading] = useState(true)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    Promise.all([loadMyProfile(), listMyReferrals()]).then(([p, r]) => {
+      if (!alive) return
+      setProfile(p)
+      setReferrals(r)
+      setLoading(false)
+    })
+    return () => { alive = false }
+  }, [])
+
+  const link = profile ? buildReferralLink(profile.referral_code) : ''
+
+  const copy = async () => {
+    if (!link) return
+    try {
+      await navigator.clipboard.writeText(link)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard can fail in insecure contexts; fall back to selecting the input.
+      const el = document.getElementById('referral-link-input') as HTMLInputElement | null
+      el?.select()
+    }
+  }
+
+  return (
+    <div className="referrals-page">
+      <div className="referrals-shell">
+        <header className="referrals-header">
+          <h1>Invite friends</h1>
+          <button type="button" className="referrals-close" onClick={onClose} aria-label="Close">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </header>
+
+        {loading ? (
+          <div className="referrals-loading">Loading…</div>
+        ) : !profile ? (
+          <div className="referrals-empty">Sign in to get your referral code.</div>
+        ) : (
+          <>
+            <section className="referrals-code-section">
+              <div className="referrals-code-label">Your code</div>
+              <div className="referrals-code">{profile.referral_code}</div>
+              <div className="referrals-link-row">
+                <input
+                  id="referral-link-input"
+                  className="referrals-link-input"
+                  type="text"
+                  readOnly
+                  value={link}
+                  onFocus={(e) => e.currentTarget.select()}
+                />
+                <button type="button" className="referrals-copy-btn" onClick={copy}>
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <p className="referrals-help">
+                Share this link. Anyone who signs up through it is attributed to you.
+              </p>
+            </section>
+
+            <section className="referrals-list-section">
+              <div className="referrals-list-header">
+                <span className="referrals-list-title">Referrals</span>
+                <span className="referrals-list-count">{referrals.length}</span>
+              </div>
+              {referrals.length === 0 ? (
+                <div className="referrals-empty">No referrals yet.</div>
+              ) : (
+                <ul className="referrals-list">
+                  {referrals.map((r) => (
+                    <li key={r.id} className="referrals-row">
+                      <span className="referrals-row-ref">{r.referee_id.slice(0, 8)}…</span>
+                      <span className="referrals-row-status" data-status={r.status}>{r.status}</span>
+                      <span className="referrals-row-date">{formatDate(r.created_at)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -347,6 +347,7 @@ export function Sidebar({ sessions, sessionsLoaded, activeSessionId, onSelect, o
             <div className="sidebar-avatar-menu">
               <div className="sidebar-avatar-menu-name">{user?.user_metadata?.full_name || user?.email || 'Local user'}</div>
               <button type="button" className="sidebar-avatar-menu-item" onClick={() => { setUserMenuOpen(false); onSettings?.() }}>Settings</button>
+              <a href="/referrals" className="sidebar-avatar-menu-item sidebar-avatar-menu-link">Invite friends</a>
               {onSignOut && <button type="button" className="sidebar-avatar-menu-item" onClick={onSignOut}>Sign out</button>}
             </div>
           )}

--- a/src/__tests__/referrals.test.ts
+++ b/src/__tests__/referrals.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+interface MockResult { data: unknown; error: unknown }
+
+let profileResult: MockResult = { data: null, error: null }
+let referralsResult: MockResult = { data: [], error: null }
+let rpcResult: MockResult = { data: false, error: null }
+const rpcCalls: Array<{ fn: string; args: unknown }> = []
+
+vi.mock('../lib/supabase', () => {
+  const makeBuilder = (result: MockResult) => {
+    const b: Record<string, unknown> = {}
+    b.select = () => b
+    b.order = () => b
+    b.maybeSingle = () => Promise.resolve(result)
+    b.then = (fn: (v: MockResult) => unknown) => Promise.resolve(result).then(fn)
+    return b
+  }
+  return {
+    supabase: {
+      from: (table: string) => {
+        if (table === 'profiles') return makeBuilder(profileResult)
+        if (table === 'referrals') return makeBuilder(referralsResult)
+        return makeBuilder({ data: null, error: null })
+      },
+      rpc: (fn: string, args: unknown) => {
+        rpcCalls.push({ fn, args })
+        return Promise.resolve(rpcResult)
+      },
+    },
+  }
+})
+
+import {
+  buildReferralLink,
+  claimReferralCode,
+  listMyReferrals,
+  loadMyProfile,
+  readRefParam,
+} from '../lib/referrals'
+
+beforeEach(() => {
+  profileResult = { data: null, error: null }
+  referralsResult = { data: [], error: null }
+  rpcResult = { data: false, error: null }
+  rpcCalls.length = 0
+})
+
+describe('readRefParam', () => {
+  it('returns the code when ?ref= is present', () => {
+    expect(readRefParam('?ref=ABC123')).toBe('ABC123')
+  })
+  it('returns null when ref is absent', () => {
+    expect(readRefParam('?other=1')).toBeNull()
+  })
+  it('returns null when ref is empty or whitespace', () => {
+    expect(readRefParam('?ref=')).toBeNull()
+    expect(readRefParam('?ref=%20%20')).toBeNull()
+  })
+})
+
+describe('buildReferralLink', () => {
+  it('uses VITE_APP_URL when set', () => {
+    const original = import.meta.env.VITE_APP_URL
+    ;(import.meta.env as Record<string, string>).VITE_APP_URL = 'https://markup.so'
+    try {
+      const link = buildReferralLink('ABC123')
+      expect(link).toContain('https://markup.so')
+      expect(link).toContain('ref=ABC123')
+    } finally {
+      ;(import.meta.env as Record<string, string>).VITE_APP_URL = original ?? ''
+    }
+  })
+  it('falls back to window.location.origin', () => {
+    ;(import.meta.env as Record<string, string>).VITE_APP_URL = ''
+    const link = buildReferralLink('CODE42')
+    expect(link).toContain('ref=CODE42')
+  })
+})
+
+describe('loadMyProfile', () => {
+  it('returns the profile row when present', async () => {
+    profileResult = {
+      data: {
+        user_id: 'u1',
+        referral_code: 'ABCD1234',
+        referred_by_user_id: null,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      error: null,
+    }
+    const p = await loadMyProfile()
+    expect(p?.referral_code).toBe('ABCD1234')
+  })
+  it('returns null on error', async () => {
+    profileResult = { data: null, error: { message: 'boom' } }
+    expect(await loadMyProfile()).toBeNull()
+  })
+})
+
+describe('claimReferralCode', () => {
+  it('returns false on empty code without calling RPC', async () => {
+    const ok = await claimReferralCode('   ')
+    expect(ok).toBe(false)
+    expect(rpcCalls).toHaveLength(0)
+  })
+  it('calls claim_referral RPC with the trimmed code', async () => {
+    rpcResult = { data: true, error: null }
+    const ok = await claimReferralCode('  CODE42  ')
+    expect(ok).toBe(true)
+    expect(rpcCalls).toEqual([{ fn: 'claim_referral', args: { p_code: 'CODE42' } }])
+  })
+  it('returns false when RPC errors', async () => {
+    rpcResult = { data: null, error: { message: 'boom' } }
+    expect(await claimReferralCode('CODE42')).toBe(false)
+  })
+  it('returns false when RPC returns false', async () => {
+    rpcResult = { data: false, error: null }
+    expect(await claimReferralCode('CODE42')).toBe(false)
+  })
+})
+
+describe('listMyReferrals', () => {
+  it('returns the rows on success', async () => {
+    referralsResult = {
+      data: [
+        {
+          id: 'r1', referrer_id: 'u1', referee_id: 'u2',
+          status: 'pending', created_at: '2026-01-01T00:00:00Z', rewarded_at: null,
+        },
+      ],
+      error: null,
+    }
+    const rows = await listMyReferrals()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('pending')
+  })
+  it('returns [] on error', async () => {
+    referralsResult = { data: null, error: { message: 'boom' } }
+    expect(await listMyReferrals()).toEqual([])
+  })
+})

--- a/src/__tests__/rls-policies.test.ts
+++ b/src/__tests__/rls-policies.test.ts
@@ -39,6 +39,8 @@ const FUTURE_TABLES = [
   'session_shares',
   'agent_memories',
   'document_snapshots',
+  'profiles',
+  'referrals',
 ] as const
 
 function loadMigrations(): string {

--- a/src/index.css
+++ b/src/index.css
@@ -233,3 +233,153 @@ body {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Referrals page */
+.referrals-page {
+  position: fixed;
+  inset: 0;
+  background: var(--surface-0);
+  z-index: 50;
+  overflow-y: auto;
+  padding: 40px 24px;
+  display: flex;
+  justify-content: center;
+}
+.referrals-shell {
+  width: 100%;
+  max-width: 640px;
+}
+.referrals-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 32px;
+}
+.referrals-header h1 {
+  font-size: 24px;
+  font-weight: 500;
+  margin: 0;
+  color: var(--text-primary);
+}
+.referrals-close {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.referrals-close:hover {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+.referrals-code-section {
+  background: var(--surface-1);
+  border: 1px solid var(--border-card);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+}
+.referrals-code-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+.referrals-code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 28px;
+  letter-spacing: 0.1em;
+  color: var(--text-primary);
+  margin-bottom: 16px;
+}
+.referrals-link-row {
+  display: flex;
+  gap: 8px;
+}
+.referrals-link-input {
+  flex: 1;
+  background: var(--surface-2);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: ui-monospace, monospace;
+}
+.referrals-copy-btn {
+  background: var(--text-primary);
+  color: var(--surface-0);
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.referrals-copy-btn:hover { opacity: 0.9; }
+.referrals-help {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 12px 0 0;
+}
+.referrals-list-section {
+  background: var(--surface-1);
+  border: 1px solid var(--border-card);
+  border-radius: 12px;
+  padding: 24px;
+}
+.referrals-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.referrals-list-title {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.referrals-list-count {
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--surface-2);
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+.referrals-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.referrals-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 0;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.referrals-row:first-child { border-top: none; }
+.referrals-row-ref { font-family: ui-monospace, monospace; color: var(--text-secondary); }
+.referrals-row-status {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+.referrals-row-status[data-status='rewarded'] { color: #30d158; }
+.referrals-row-date { color: var(--text-secondary); font-size: 12px; }
+.referrals-loading, .referrals-empty {
+  color: var(--text-secondary);
+  font-size: 14px;
+  padding: 24px;
+  text-align: center;
+}

--- a/src/lib/referrals.ts
+++ b/src/lib/referrals.ts
@@ -1,0 +1,81 @@
+import { supabase } from './supabase'
+
+export interface Profile {
+  user_id: string
+  referral_code: string
+  referred_by_user_id: string | null
+  created_at: string
+}
+
+export interface Referral {
+  id: string
+  referrer_id: string
+  referee_id: string
+  status: 'pending' | 'rewarded' | 'void'
+  created_at: string
+  rewarded_at: string | null
+}
+
+/** Load the caller's profile row. Returns null if not signed in or absent. */
+export async function loadMyProfile(): Promise<Profile | null> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .maybeSingle()
+  if (error) return null
+  return (data as Profile | null) ?? null
+}
+
+/**
+ * Attempt to claim a referral code for the current user. Resolves `true`
+ * on success, `false` on any silent rejection (invalid code, self-ref,
+ * already attributed). Never throws for validation failures — the server
+ * RPC swallows them.
+ */
+export async function claimReferralCode(code: string): Promise<boolean> {
+  const trimmed = code.trim()
+  if (!trimmed) return false
+  const { data, error } = await supabase.rpc('claim_referral', { p_code: trimmed })
+  if (error) return false
+  return data === true
+}
+
+/** List referrals where the caller is the referrer, newest first. */
+export async function listMyReferrals(): Promise<Referral[]> {
+  const { data, error } = await supabase
+    .from('referrals')
+    .select('*')
+    .order('created_at', { ascending: false })
+  if (error) return []
+  return (data as Referral[] | null) ?? []
+}
+
+/**
+ * Build a shareable referral URL. Prefers VITE_APP_URL so staging/prod
+ * don't leak the current tab's localhost. Falls back to the current
+ * origin. The ref is placed on `/` since the signup flow lives at the
+ * root (see LoginPage).
+ */
+export function buildReferralLink(code: string): string {
+  const envBase = import.meta.env.VITE_APP_URL as string | undefined
+  const base = envBase?.trim() || (typeof window !== 'undefined' ? window.location.origin : '')
+  const url = new URL('/', base || 'https://example.com')
+  url.searchParams.set('ref', code)
+  return url.toString()
+}
+
+/**
+ * Pull a referral code from a URL's query string. Returns null when no
+ * `?ref=` is present. Used at app bootstrap to defer a claim until the
+ * user has completed sign-in.
+ */
+export function readRefParam(search: string = typeof window !== 'undefined' ? window.location.search : ''): string | null {
+  const params = new URLSearchParams(search)
+  const raw = params.get('ref')
+  if (!raw) return null
+  const trimmed = raw.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+/** localStorage key for a pending referral code awaiting a signed-in user. */
+export const PENDING_REF_STORAGE_KEY = 'markup-pending-ref'

--- a/supabase/migrations/013_profiles_referrals.sql
+++ b/supabase/migrations/013_profiles_referrals.sql
@@ -1,0 +1,168 @@
+-- Profiles: one row per authenticated user. Holds data that can't live on
+-- auth.users directly (which Supabase owns). Each user gets a short,
+-- shareable referral_code at signup. `referred_by_user_id` records which
+-- existing user attributed this signup (set once, at claim time).
+--
+-- The signup -> profile row link is wired via an auth.users trigger so the
+-- app never has to remember to create the row; the first time the app
+-- queries `profiles` for a given user, the row is already there.
+
+create table if not exists profiles (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  referral_code text not null unique,
+  referred_by_user_id uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint profiles_no_self_ref check (referred_by_user_id is null or referred_by_user_id <> user_id)
+);
+
+create index if not exists idx_profiles_referred_by
+  on profiles(referred_by_user_id)
+  where referred_by_user_id is not null;
+
+-- 8-character code from an unambiguous alphabet (no 0/O/1/I/L). Collisions
+-- are handled by a unique-constraint retry loop in the insert trigger.
+create or replace function gen_referral_code()
+returns text
+language plpgsql
+as $$
+declare
+  alphabet text := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+  code text := '';
+  i int;
+begin
+  for i in 1..8 loop
+    code := code || substr(alphabet, 1 + floor(random() * length(alphabet))::int, 1);
+  end loop;
+  return code;
+end;
+$$;
+
+-- Create a profile row whenever a new auth user appears. Retries on the
+-- off chance the generated code collides. SECURITY DEFINER so it can
+-- insert regardless of the caller's RLS context (the trigger runs as the
+-- auth user during signup, which has no direct insert permission on
+-- profiles under the RLS policy below).
+create or replace function handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  new_code text;
+  attempts int := 0;
+begin
+  loop
+    new_code := gen_referral_code();
+    begin
+      insert into profiles (user_id, referral_code) values (new.id, new_code);
+      return new;
+    exception when unique_violation then
+      attempts := attempts + 1;
+      if attempts >= 5 then
+        raise;
+      end if;
+    end;
+  end loop;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function handle_new_user();
+
+-- Backfill: create profile rows for any existing users who signed up
+-- before this migration.
+insert into profiles (user_id, referral_code)
+select u.id, gen_referral_code()
+from auth.users u
+where not exists (select 1 from profiles p where p.user_id = u.id)
+on conflict (user_id) do nothing;
+
+-- Referrals ledger. One row per successful attribution. `status` leaves
+-- room for future reward fulfillment (pending -> rewarded). `rewarded_at`
+-- is the hook the bead calls out as non-goals for now.
+create table if not exists referrals (
+  id uuid primary key default gen_random_uuid(),
+  referrer_id uuid not null references auth.users(id) on delete cascade,
+  referee_id uuid not null references auth.users(id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending', 'rewarded', 'void')),
+  created_at timestamptz not null default now(),
+  rewarded_at timestamptz,
+  constraint referrals_no_self check (referrer_id <> referee_id),
+  -- A referee is attributed to at most one referrer.
+  unique (referee_id)
+);
+
+create index if not exists idx_referrals_referrer
+  on referrals(referrer_id, created_at desc);
+
+-- RLS. Profiles: a user reads their own row. Update is restricted to
+-- empty-attribution rows and only via the claim_referral RPC, so we do
+-- NOT grant a direct update policy; the RPC is SECURITY DEFINER.
+alter table profiles enable row level security;
+
+create policy "Users can read own profile"
+  on profiles for select
+  using (auth.uid() = user_id);
+
+-- Referrals: a user sees rows where they are either the referrer or the
+-- referee. Insert/update/delete go through the claim_referral RPC, so
+-- no direct write policies.
+alter table referrals enable row level security;
+
+create policy "Users can read their referrals"
+  on referrals for select
+  using (auth.uid() = referrer_id or auth.uid() = referee_id);
+
+-- Claim a referral code for the calling user. Fails silently (returns
+-- false) on any validation miss: unknown code, self-referral, or the
+-- caller has already been attributed. Succeeds exactly once per user.
+create or replace function claim_referral(p_code text)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  caller_id uuid := auth.uid();
+  referrer uuid;
+  normalized_code text;
+begin
+  if caller_id is null then
+    return false;
+  end if;
+  if p_code is null then
+    return false;
+  end if;
+  normalized_code := upper(trim(p_code));
+  if normalized_code = '' then
+    return false;
+  end if;
+
+  select user_id into referrer from profiles where referral_code = normalized_code;
+  if referrer is null then
+    return false;
+  end if;
+  if referrer = caller_id then
+    return false;
+  end if;
+
+  update profiles
+    set referred_by_user_id = referrer
+    where user_id = caller_id
+      and referred_by_user_id is null;
+  if not found then
+    return false;
+  end if;
+
+  insert into referrals (referrer_id, referee_id)
+    values (referrer, caller_id)
+    on conflict (referee_id) do nothing;
+
+  return true;
+end;
+$$;
+
+grant execute on function claim_referral(text) to authenticated;


### PR DESCRIPTION
## Summary
User referral system on top of Supabase auth: each user gets a unique 8-char referral code at profile creation, signup flow accepts `?ref=CODE` to attribute new users, dashboard page shows code + copy-link + referral list.

- Migration 013: `profiles` table with referral_code (unique) + referred_by_user_id; `referrals` table with RLS (owner-read); trigger to auto-generate code on first profile load
- `src/lib/referrals.ts`: code generation, attribution on signup, referral fetch
- UI: referrals dashboard + copy-link
- RLS regression test included

Closes mk-rsd.

## Test plan
- [ ] Sign up new user → profile row created with unique referral_code
- [ ] Visit `/?ref=CODE` → sign up → referrer_id attributed on new profile
- [ ] Self-referral silently rejected (no attribution)
- [ ] Invalid code silently rejected
- [ ] Dashboard shows code + copy button + referral list
- [ ] RLS: user cannot read other users' referrals
- [ ] `npm run build`, `typecheck`, `lint`, `test` pass

⚠️ **Requires mk-4iy** — migration 013 must be applied to live Supabase before this ships. Same blocker as mk-hoz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
