### PR TITLE
test: assert migration 011 drops agent_tasks anon policy (mk-xpw)

### DIFF
--- a/src/__tests__/rls-policies.test.ts
+++ b/src/__tests__/rls-policies.test.ts
@@ -148,6 +148,12 @@ describe('RLS policy boundaries (migrations)', () => {
         /drop\s+policy\s+if\s+exists\s+"public_personas"\s+on\s+agent_personas/
       )
     })
+
+    it('does not leave an "Allow all for anon" policy active on agent_tasks', () => {
+      expect(sql).toMatch(
+        /drop\s+policy\s+if\s+exists\s+"allow all for anon"\s+on\s+agent_tasks/
+      )
+    })
   })
 
   describe('cross-user isolation shape', () => {


### PR DESCRIPTION
## Summary
Adds regression test in `rls-policies.test.ts` asserting migration 011 contains the `drop policy if exists \"Allow all for anon\" on agent_tasks` statement, matching the pattern used for other migrations. Addresses Copilot review item 5 from PR #270.

Closes mk-xpw.

## Test plan
- [ ] `npm run test src/__tests__/rls-policies.test.ts` passes with the new assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
