### PR TITLE
feat(api): Zod validation + length cap on /api/gemini

### DIFF
--- a/api/gemini.ts
+++ b/api/gemini.ts
@@ -4,6 +4,16 @@ import { generateText } from 'ai'
 import { LangfuseSpanProcessor } from '@langfuse/otel'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
 import { startActiveObservation, propagateAttributes } from '@langfuse/tracing'
+import { z } from 'zod'
+
+// Hard cap on prompt length. Gemini 2.5 Flash has a ~1M token context; 200k
+// characters is a conservative server-side guard against runaway client input
+// without biting into legitimate long-document prompts.
+const MAX_PROMPT_LENGTH = 200_000
+
+export const geminiRequestBodySchema = z.object({
+  prompt: z.string().min(1, 'prompt must not be empty').max(MAX_PROMPT_LENGTH, `prompt must be <= ${MAX_PROMPT_LENGTH} characters`),
+})
 
 // Langfuse tracing setup (inline to avoid cross-file import issues in Vercel serverless)
 // Trim env vars to handle trailing whitespace/newlines from Vercel env config
@@ -55,10 +65,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const userId = req.headers['x-user-id'] as string | undefined
   const agentName = req.headers['x-agent-name'] as string | undefined
 
-  const { prompt } = req.body || {}
-  if (!prompt || typeof prompt !== 'string') {
-    return res.status(400).json({ error: 'Missing prompt in request body', code: 'BAD_REQUEST', status: 400 })
+  const parsed = geminiRequestBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const path = issue.path.join('.') || '(body)'
+    return res.status(400).json({
+      error: `Invalid request body: ${path}: ${issue.message}`,
+      code: 'BAD_REQUEST',
+      status: 400,
+      issues: parsed.error.issues,
+    })
   }
+  const { prompt } = parsed.data
 
   const google = createGoogleGenerativeAI({ apiKey })
 

--- a/src/__tests__/gemini-request-schema.test.ts
+++ b/src/__tests__/gemini-request-schema.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { geminiRequestBodySchema } from '../../api/gemini'
+
+describe('geminiRequestBodySchema', () => {
+  it('accepts a valid prompt', () => {
+    const result = geminiRequestBodySchema.safeParse({ prompt: 'hello' })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.prompt).toBe('hello')
+  })
+
+  it('rejects missing prompt', () => {
+    const result = geminiRequestBodySchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-string prompt', () => {
+    const result = geminiRequestBodySchema.safeParse({ prompt: 123 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty prompt', () => {
+    const result = geminiRequestBodySchema.safeParse({ prompt: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/empty|length/i)
+    }
+  })
+
+  it('rejects null body', () => {
+    const result = geminiRequestBodySchema.safeParse(null)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a prompt over the length cap', () => {
+    const huge = 'x'.repeat(200_001)
+    const result = geminiRequestBodySchema.safeParse({ prompt: huge })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a prompt at exactly the length cap', () => {
+    const atLimit = 'x'.repeat(200_000)
+    const result = geminiRequestBodySchema.safeParse({ prompt: atLimit })
+    expect(result.success).toBe(true)
+  })
+})


### PR DESCRIPTION
Salvaged from polecat dag's worktree. Adds Zod schema validation (non-empty + 200k char cap) on the gemini API endpoint with structured error responses + a 7-test vitest suite.

Auto-mergeable if CI passes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
