### PR TITLE
feat(marketing): build multi-page landing site (mk-rn7)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7196,3 +7196,1029 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
     animation: none;
   }
 }
+
+/* ============================================================
+   Marketing multi-page site — shared chrome overrides
+   ============================================================ */
+
+.marketing-nav-link.is-active {
+  color: var(--text-primary);
+  position: relative;
+}
+
+.marketing-nav-link.is-active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 1px;
+  background: var(--text-primary);
+  opacity: 0.6;
+}
+
+.marketing-footer {
+  padding: 48px 48px 36px;
+}
+
+.marketing-footer-inner {
+  align-items: flex-start;
+  gap: 28px;
+}
+
+.marketing-footer-columns {
+  display: flex;
+  gap: 56px;
+  flex-wrap: wrap;
+  flex: 1;
+  justify-content: center;
+}
+
+.marketing-footer-col {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 120px;
+}
+
+.marketing-footer-heading {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-tertiary);
+  margin-bottom: 4px;
+}
+
+.marketing-footer-col .marketing-footer-link {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.marketing-footer-col .marketing-footer-link:hover,
+.marketing-footer-col .marketing-footer-link:focus-visible {
+  color: var(--text-primary);
+}
+
+/* Shared page header used by all sub-pages */
+.marketing-page-header {
+  text-align: center;
+  padding: 96px 0 48px;
+  max-width: 760px;
+  margin: 0 auto;
+  animation: headlineIn 0.7s var(--ease-out-expo) 0.05s both;
+}
+
+.marketing-page-title {
+  margin: 12px 0 0;
+  font-family: var(--font-serif);
+  font-weight: 300;
+  font-size: clamp(36px, 6vw, 64px);
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  color: var(--text-primary);
+}
+
+.marketing-page-title-italic {
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+.marketing-page-lede {
+  margin: 24px auto 0;
+  max-width: 600px;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+.marketing-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-secondary);
+  margin-bottom: 28px;
+}
+
+/* ============================================================
+   Home page — hero highlights grid
+   ============================================================ */
+
+.marketing-highlights .marketing-highlight-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.marketing-highlight-card {
+  display: flex;
+  flex-direction: column;
+  padding: 28px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--duration-fast) ease, background var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+}
+
+.marketing-highlight-card:hover {
+  background: var(--surface-2);
+  border-color: var(--border-default);
+  transform: translateY(-2px);
+}
+
+.marketing-highlight-title {
+  margin: 10px 0 10px;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.marketing-highlight-body {
+  margin: 0 0 18px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  flex: 1;
+}
+
+.marketing-highlight-link {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-decoration: none;
+  transition: color var(--duration-fast) ease;
+}
+
+.marketing-highlight-link:hover,
+.marketing-highlight-link:focus-visible {
+  color: var(--accent-active);
+}
+
+/* ============================================================
+   Features page
+   ============================================================ */
+
+.marketing-page-features .features-pillars {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  margin: 48px 0 96px;
+}
+
+.features-pillar {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 48px;
+  padding: 40px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.features-pillar:last-child { border-bottom: none; }
+
+.features-pillar-index {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+  padding-top: 6px;
+}
+
+.features-pillar-body {
+  max-width: 680px;
+}
+
+.features-pillar-title {
+  margin: 0 0 14px;
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: clamp(22px, 3vw, 30px);
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.features-pillar-copy {
+  margin: 0 0 14px;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.features-pillar-note {
+  margin: 0;
+  padding: 10px 14px;
+  border-left: 2px solid var(--border-default);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  background: var(--surface-1);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+
+.features-cap-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1px;
+  background: var(--border-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.features-cap-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 22px 24px;
+  background: var(--surface-0);
+}
+
+.features-cap-label {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.features-cap-detail {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.features-faq {
+  padding: 96px 0;
+}
+
+/* ============================================================
+   Pricing page
+   ============================================================ */
+
+.marketing-page-pricing .pricing-tiers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 48px 0 96px;
+  align-items: stretch;
+}
+
+.pricing-tier {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 32px 28px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  transition: border-color var(--duration-fast) ease, transform var(--duration-fast) ease;
+}
+
+.pricing-tier:hover { transform: translateY(-2px); }
+
+.pricing-tier.is-featured {
+  background: linear-gradient(180deg, var(--surface-2), var(--surface-1));
+  border-color: var(--border-default);
+  box-shadow: 0 0 0 1px var(--border-subtle) inset;
+}
+
+.pricing-tier-badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 5px 12px;
+  background: var(--text-primary);
+  color: var(--surface-0);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-radius: var(--radius-pill);
+}
+
+.pricing-tier-head { margin-bottom: 24px; }
+
+.pricing-tier-name {
+  margin: 0 0 12px;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pricing-tier-price {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.pricing-tier-amount {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: 44px;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.pricing-tier-cadence {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+.pricing-tier-desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+.pricing-tier-features {
+  list-style: none;
+  margin: 0 0 28px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.pricing-tier-features li {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.pricing-check {
+  color: #30d158;
+  font-weight: 600;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.pricing-tier-cta { width: 100%; }
+
+.pricing-compare {
+  padding: 72px 0;
+}
+
+.pricing-compare-table {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--surface-1);
+}
+
+.pricing-compare-head,
+.pricing-compare-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+}
+
+.pricing-compare-head {
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.pricing-compare-row { border-bottom: 1px solid var(--border-subtle); }
+.pricing-compare-row:last-child { border-bottom: none; }
+
+.pricing-compare-cell {
+  padding: 14px 20px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+}
+
+.pricing-compare-head .pricing-compare-cell {
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+}
+
+.pricing-compare-rowlabel {
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.pricing-faq { padding: 48px 0 96px; }
+
+/* ============================================================
+   About page
+   ============================================================ */
+
+.marketing-page-about .about-header { max-width: 720px; }
+
+.about-manifesto {
+  max-width: 720px;
+  margin: 48px auto 96px;
+  padding: 48px 0;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.about-manifesto-title {
+  margin: 0 0 28px;
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(22px, 3vw, 28px);
+  line-height: 1.35;
+  color: var(--text-primary);
+}
+
+.about-manifesto-body p {
+  margin: 0 0 16px;
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+.about-manifesto-body p:last-child { margin-bottom: 0; }
+
+.about-principles-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.about-principle {
+  padding: 28px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+}
+
+.about-principle-n {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.1em;
+  margin-bottom: 14px;
+}
+
+.about-principle-title {
+  margin: 0 0 10px;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.about-principle-body {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.about-timeline {
+  padding: 96px 0;
+}
+
+.about-timeline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+}
+
+.about-timeline-list::before {
+  content: '';
+  position: absolute;
+  left: 110px;
+  top: 8px;
+  bottom: 8px;
+  width: 1px;
+  background: var(--border-subtle);
+}
+
+.about-timeline-item {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 32px;
+  padding: 18px 0;
+  position: relative;
+}
+
+.about-timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 106px;
+  top: 28px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--text-primary);
+  border: 2px solid var(--surface-0);
+}
+
+.about-timeline-when {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.06em;
+  padding-top: 2px;
+}
+
+.about-timeline-what {
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+.about-signoff {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 48px 0 96px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 36px;
+}
+
+.about-signoff-quote {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.about-signoff-quote p {
+  font-family: var(--font-serif);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(22px, 3vw, 28px);
+  line-height: 1.4;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.about-signoff-footer {
+  margin-top: 18px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--text-tertiary);
+  font-style: normal;
+}
+
+/* ============================================================
+   Use cases page
+   ============================================================ */
+
+.marketing-page-usecases .usecases-jump {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin: 24px 0 64px;
+}
+
+.usecases-jump-link {
+  padding: 8px 16px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: border-color var(--duration-fast) ease, color var(--duration-fast) ease;
+}
+
+.usecases-jump-link:hover,
+.usecases-jump-link:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--border-default);
+}
+
+.usecases-list {
+  display: flex;
+  flex-direction: column;
+  gap: 96px;
+  padding-bottom: 96px;
+}
+
+.usecases-scenario {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: center;
+  scroll-margin-top: 96px;
+}
+
+.usecases-scenario.is-reverse .usecases-scenario-copy { order: 2; }
+.usecases-scenario.is-reverse .usecases-scenario-demo { order: 1; }
+
+.usecases-scenario-title {
+  margin: 12px 0 16px;
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: clamp(26px, 3.5vw, 34px);
+  letter-spacing: -0.015em;
+  line-height: 1.2;
+  color: var(--text-primary);
+}
+
+.usecases-scenario-summary {
+  margin: 0 0 24px;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-width: 520px;
+}
+
+.usecases-panel {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.usecases-panel-item {
+  display: grid;
+  grid-template-columns: 14px auto 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-family: var(--font-ui);
+  font-size: 13px;
+}
+
+.usecases-panel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.usecases-panel-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.usecases-panel-note {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.usecases-scenario-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 28px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 40px 80px -40px rgba(0, 0, 0, 0.5);
+}
+
+.usecases-demo-line {
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.usecases-demo-line p {
+  margin: 8px 0 0;
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+
+.usecases-demo-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.usecases-demo-after {
+  background: var(--accent-container);
+  border: 1px solid var(--border-default);
+}
+
+.usecases-demo-after p {
+  font-family: var(--font-body);
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-style: italic;
+}
+
+.usecases-demo-arrow {
+  text-align: center;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  font-size: 18px;
+}
+
+/* ============================================================
+   Agents page
+   ============================================================ */
+
+.marketing-page-agents .agents-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+  margin: 48px 0 96px;
+}
+
+.agents-card {
+  position: relative;
+  padding: 32px 28px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  transition: border-color var(--duration-fast) ease, transform var(--duration-fast) ease;
+}
+
+.agents-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--agent-accent);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  opacity: 0.85;
+}
+
+.agents-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-default);
+}
+
+.agents-card-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.agents-card-ring {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 2px solid var(--agent-accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.agents-card-dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--agent-accent);
+}
+
+.agents-card-name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.agents-card-role {
+  margin: 2px 0 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.agents-card-tagline {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+.agents-card-persona {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.agents-card-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agents-card-label {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.agents-card-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agents-card-list li {
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding-left: 16px;
+  position: relative;
+}
+
+.agents-card-list li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  width: 6px;
+  height: 1px;
+  background: var(--agent-accent);
+}
+
+.agents-card-tells {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.agents-card-tells li {
+  padding: 5px 10px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.agents-card-sample {
+  margin: 0;
+  padding: 18px 20px;
+  background: var(--surface-2);
+  border-left: 3px solid var(--agent-accent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+}
+
+.agents-card-sample p {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--text-primary);
+}
+
+.agents-card-sample footer {
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.agents-card-sample-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--agent-accent);
+}
+
+.agents-byo {
+  text-align: center;
+  padding: 72px 0 96px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.agents-byo-body {
+  max-width: 560px;
+  margin: 0 auto 28px;
+  font-size: 15px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+}
+
+/* ============================================================
+   Responsive rules for new pages
+   ============================================================ */
+
+@media (max-width: 820px) {
+  .marketing-footer { padding: 36px 20px 28px; }
+  .marketing-footer-inner { gap: 24px; }
+  .marketing-footer-columns { justify-content: flex-start; gap: 32px; }
+  .marketing-page-header { padding: 64px 0 32px; }
+
+  .features-pillar {
+    grid-template-columns: 1fr;
+    gap: 14px;
+    padding: 28px 0;
+  }
+
+  .pricing-compare-head,
+  .pricing-compare-row {
+    grid-template-columns: 1.5fr 1fr 1fr 1fr;
+  }
+  .pricing-compare-cell { padding: 12px; font-size: 12px; }
+
+  .about-timeline-list::before { left: 78px; }
+  .about-timeline-item { grid-template-columns: 78px 1fr; gap: 20px; }
+  .about-timeline-item::before { left: 74px; }
+
+  .usecases-scenario {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+  .usecases-scenario.is-reverse .usecases-scenario-copy,
+  .usecases-scenario.is-reverse .usecases-scenario-demo {
+    order: initial;
+  }
+  .usecases-list { gap: 64px; padding-bottom: 64px; }
+
+  .agents-card { padding: 24px 20px; }
+}
+
+@media (max-width: 480px) {
+  .marketing-footer-columns { gap: 24px; }
+  .marketing-footer-col { min-width: 100%; }
+  .pricing-compare-table { font-size: 11px; }
+  .pricing-compare-head,
+  .pricing-compare-row {
+    grid-template-columns: 1.6fr 0.8fr 0.8fr 0.8fr;
+  }
+  .pricing-compare-cell { padding: 10px 8px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .marketing-page-header,
+  .marketing-highlight-card,
+  .pricing-tier,
+  .agents-card {
+    animation: none;
+    transition: none;
+  }
+  .marketing-highlight-card:hover,
+  .pricing-tier:hover,
+  .agents-card:hover { transform: none; }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,11 @@ import { loadUserSettings, saveGeminiApiKey } from './lib/settings-store'
 // Lazy-loaded components (not needed on initial render)
 const LoginPage = lazy(() => import('./LoginPage').then(m => ({ default: m.LoginPage })))
 const MarketingPage = lazy(() => import('./MarketingPage').then(m => ({ default: m.MarketingPage })))
+const FeaturesPage = lazy(() => import('./marketing/FeaturesPage').then(m => ({ default: m.FeaturesPage })))
+const PricingPage = lazy(() => import('./marketing/PricingPage').then(m => ({ default: m.PricingPage })))
+const AboutPage = lazy(() => import('./marketing/AboutPage').then(m => ({ default: m.AboutPage })))
+const UseCasesPage = lazy(() => import('./marketing/UseCasesPage').then(m => ({ default: m.UseCasesPage })))
+const AgentsPage = lazy(() => import('./marketing/AgentsPage').then(m => ({ default: m.AgentsPage })))
 const LegalPage = lazy(() => import('./LegalPage').then(m => ({ default: m.LegalPage })))
 const ReferralsPage = lazy(() => import('./ReferralsPage').then(m => ({ default: m.ReferralsPage })))
 const ChangelogPage = lazy(() => import('./ChangelogPage').then(m => ({ default: m.ChangelogPage })))
@@ -483,6 +488,13 @@ function App() {
   if (window.location.pathname === '/privacy') return <Suspense><LegalPage page="privacy" /></Suspense>
   if (window.location.pathname === '/terms') return <Suspense><LegalPage page="terms" /></Suspense>
   if (window.location.pathname === '/changelog') return <Suspense><ChangelogPage /></Suspense>
+
+  // Marketing sub-pages -- always accessible, even to signed-in users
+  if (window.location.pathname === '/features') return <Suspense><FeaturesPage /></Suspense>
+  if (window.location.pathname === '/pricing') return <Suspense><PricingPage /></Suspense>
+  if (window.location.pathname === '/about') return <Suspense><AboutPage /></Suspense>
+  if (window.location.pathname === '/use-cases') return <Suspense><UseCasesPage /></Suspense>
+  if (window.location.pathname === '/agents') return <Suspense><AgentsPage /></Suspense>
 
   // Referrals page -- requires a signed-in user (or localhost).
   // Uses full-page nav on close to match the legal-pages pattern so the

--- a/src/MarketingPage.tsx
+++ b/src/MarketingPage.tsx
@@ -1,9 +1,5 @@
-import { lazy, Suspense } from 'react'
-import { MarkupLogo } from './MarkupLogo'
-
-const ColorPanels = lazy(() =>
-  import('@paper-design/shaders-react').then(m => ({ default: m.ColorPanels }))
-)
+import { MarketingLayout } from './marketing/MarketingLayout'
+import { goToLogin } from './marketing/utils'
 
 const AGENT_CARDS = [
   {
@@ -32,246 +28,108 @@ const AGENT_CARDS = [
   },
 ]
 
-const FEATURES = [
+const HIGHLIGHTS = [
   {
-    title: 'Four perspectives, one draft',
-    body: 'Engineering, product, legal, and design agents read the same document and push back where it matters — not a single generic voice.',
+    eyebrow: 'Features',
+    href: '/features',
+    title: 'A standing panel, at draft speed',
+    body: 'Four specialist voices reading the same doc. Real-time cursors, inline edits, push-back where it matters.',
   },
   {
-    title: 'Ambient, not chatbot',
-    body: 'Agents live inside your document. Watch their cursors move, read their thoughts, see them edit and comment in real time.',
+    eyebrow: 'Use cases',
+    href: '/use-cases',
+    title: 'PRDs, specs, RFCs, briefs',
+    body: 'The documents that live or die by review. Markup gives you the review loop before the stakeholder one.',
   },
   {
-    title: 'Built to disagree',
-    body: 'Agents are tuned to push back, not praise. They surface gaps, risks, and weak assumptions before stakeholders do.',
-  },
-  {
-    title: 'Ships with presets',
-    body: 'Start with PRDs, specs, briefs, or RFCs. Swap agents, rewrite personas, or bring your own. Your doc, your team.',
-  },
-]
-
-const STEPS = [
-  {
-    n: '01',
-    title: 'Start a draft',
-    body: 'Pick a template or paste in what you have — PRD, spec, brief, launch plan.',
-  },
-  {
-    n: '02',
-    title: 'Pick your reviewers',
-    body: 'Aiden, Nova, Lex, Mira — or a subset. Tune each persona if you want.',
-  },
-  {
-    n: '03',
-    title: 'Ship with fewer surprises',
-    body: 'Agents read, challenge, and edit alongside you until the draft holds up.',
-  },
-]
-
-const FAQ = [
-  {
-    q: 'What does Markup actually do?',
-    a: 'Markup is a shared writing surface where AI agents with distinct specialties review and edit your document alongside you. Think less "AI writes for me" and more "a standing review panel that works at draft speed."',
-  },
-  {
-    q: 'Who is this for?',
-    a: 'Product managers, engineers, and founders who write PRDs, specs, RFCs, and briefs — the kind of document that lives or dies by the feedback it gets before it ships.',
-  },
-  {
-    q: 'Which models do the agents use?',
-    a: 'Agents run on Google Gemini 2.5 Flash today. Each agent has its own system prompt and rhythm so their feedback reads distinct instead of averaged.',
-  },
-  {
-    q: 'Can I change the agents?',
-    a: 'Yes. You can swap presets, edit personas, or add up to four agents per session. The underlying orchestration keeps them from stepping on each other.',
-  },
-  {
-    q: 'Is my writing used to train anything?',
-    a: 'No. Your documents stay in your account. Drafts and chat are stored per-session and are not used to train models.',
-  },
-  {
-    q: 'How much does it cost?',
-    a: 'Markup is free while in early access. Sign in with Google or email and start drafting.',
+    eyebrow: 'Agents',
+    href: '/agents',
+    title: 'Meet Aiden, Nova, Lex, Mira',
+    body: 'Engineering, product, legal, design. Distinct personas, tuned rhythms, built to disagree.',
   },
 ]
 
 export function MarketingPage() {
-  const goToLogin = (mode: 'signin' | 'signup' = 'signin') => {
-    const target = mode === 'signup' ? '/?login=1&mode=signup' : '/?login=1'
-    window.location.href = target
-  }
-
   return (
-    <div className="marketing-page">
-      <div className="marketing-shader" aria-hidden="true">
-        <Suspense fallback={null}>
-          <ColorPanels
-            speed={0.35}
-            scale={1.4}
-            density={2}
-            angle1={0}
-            angle2={0}
-            length={1.2}
-            edges={false}
-            blur={0}
-            fadeIn={1}
-            fadeOut={0.5}
-            gradient={0}
-            rotation={0}
-            offsetX={0}
-            offsetY={0}
-            maxPixelCount={1920 * 1080}
-            minPixelRatio={1}
-            colors={['#FF9D00', '#FD4F30', '#809BFF', '#6D2EFF', '#333AFF', '#F15CFF', '#FFD557']}
-            colorBack="#00000000"
-            style={{ height: '100%', width: '100%', mixBlendMode: 'screen', opacity: 0.45 }}
-          />
-        </Suspense>
-      </div>
-
-      <nav className="marketing-nav" aria-label="Primary">
-        <a href="/" className="marketing-nav-logo" aria-label="Markup home">
-          <MarkupLogo height={20} />
-        </a>
-        <div className="marketing-nav-links">
-          <a href="#features" className="marketing-nav-link">Features</a>
-          <a href="#how" className="marketing-nav-link">How it works</a>
-          <a href="#faq" className="marketing-nav-link">FAQ</a>
-        </div>
-        <div className="marketing-nav-actions">
+    <MarketingLayout pageClass="marketing-page-home" shader="warm" activePath="/">
+      <section className="marketing-hero" aria-labelledby="hero-headline">
+        <span className="marketing-pill">Early access · free while it lasts</span>
+        <h1 id="hero-headline" className="marketing-headline">
+          <span className="marketing-headline-line">Every draft, reviewed by</span>
+          <span className="marketing-headline-line marketing-headline-italic">four experts.</span>
+        </h1>
+        <p className="marketing-subtitle">
+          Markup is a writing surface where AI agents for engineering, product, legal, and design
+          read your docs and push back on what you missed — in the draft, not after it ships.
+        </p>
+        <div className="marketing-cta-row">
           <button
             type="button"
-            className="marketing-nav-link marketing-nav-signin"
-            onClick={() => goToLogin('signin')}
-          >
-            Sign in
-          </button>
-          <button
-            type="button"
-            className="marketing-cta-primary marketing-nav-cta"
+            className="marketing-cta-primary"
             onClick={() => goToLogin('signup')}
           >
-            Get started
+            Start writing free
           </button>
+          <a href="/features" className="marketing-cta-secondary">
+            See how it works
+          </a>
         </div>
-      </nav>
 
-      <main className="marketing-main">
-        <section className="marketing-hero" aria-labelledby="hero-headline">
-          <h1 id="hero-headline" className="marketing-headline">
-            <span className="marketing-headline-line">Every draft, reviewed by</span>
-            <span className="marketing-headline-line marketing-headline-italic">four experts.</span>
-          </h1>
-          <p className="marketing-subtitle">
-            Markup is a writing surface where AI agents for engineering, product, legal, and design
-            read your docs and push back on what you missed — in the draft, not after it ships.
-          </p>
-          <div className="marketing-cta-row">
-            <button
-              type="button"
-              className="marketing-cta-primary"
-              onClick={() => goToLogin('signup')}
-            >
-              Start writing free
-            </button>
-            <button
-              type="button"
-              className="marketing-cta-secondary"
-              onClick={() => {
-                const el = document.getElementById('features')
-                el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-              }}
-            >
-              See how it works
-            </button>
-          </div>
+        <ul className="marketing-agent-row" aria-label="Your review panel">
+          {AGENT_CARDS.map(a => (
+            <li key={a.name} className="marketing-agent-chip">
+              <span
+                className="marketing-agent-dot"
+                style={{ background: a.color }}
+                aria-hidden="true"
+              />
+              <span className="marketing-agent-name">{a.name}</span>
+              <span className="marketing-agent-role">{a.role}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
-          <ul className="marketing-agent-row" aria-label="Your review panel">
-            {AGENT_CARDS.map(a => (
-              <li key={a.name} className="marketing-agent-chip">
-                <span
-                  className="marketing-agent-dot"
-                  style={{ background: a.color }}
-                  aria-hidden="true"
-                />
-                <span className="marketing-agent-name">{a.name}</span>
-                <span className="marketing-agent-role">{a.role}</span>
-              </li>
-            ))}
-          </ul>
-        </section>
+      <section className="marketing-proof" aria-label="Social proof">
+        <p className="marketing-proof-label">Built on</p>
+        <ul className="marketing-proof-list">
+          <li>React 19</li>
+          <li>Tiptap 3</li>
+          <li>Gemini 2.5 Flash</li>
+          <li>Supabase</li>
+          <li>Vercel</li>
+        </ul>
+      </section>
 
-        <section className="marketing-proof" aria-label="Social proof">
-          <p className="marketing-proof-label">Built on</p>
-          <ul className="marketing-proof-list">
-            <li>React 19</li>
-            <li>Tiptap 3</li>
-            <li>Gemini 2.5 Flash</li>
-            <li>Supabase</li>
-            <li>Vercel</li>
-          </ul>
-        </section>
-
-        <section id="features" className="marketing-section" aria-labelledby="features-title">
-          <header className="marketing-section-header">
-            <p className="marketing-eyebrow">Features</p>
-            <h2 id="features-title" className="marketing-section-title">
-              A standing review panel, at draft speed
-            </h2>
-          </header>
-          <ul className="marketing-feature-grid">
-            {FEATURES.map(f => (
-              <li key={f.title} className="marketing-feature-card">
-                <h3 className="marketing-feature-title">{f.title}</h3>
-                <p className="marketing-feature-body">{f.body}</p>
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <section id="how" className="marketing-section" aria-labelledby="how-title">
-          <header className="marketing-section-header">
-            <p className="marketing-eyebrow">How it works</p>
-            <h2 id="how-title" className="marketing-section-title">
-              Three steps, no setup theatre
-            </h2>
-          </header>
-          <ol className="marketing-steps">
-            {STEPS.map(s => (
-              <li key={s.n} className="marketing-step">
-                <span className="marketing-step-n">{s.n}</span>
-                <h3 className="marketing-step-title">{s.title}</h3>
-                <p className="marketing-step-body">{s.body}</p>
-              </li>
-            ))}
-          </ol>
-        </section>
-
-        <section id="faq" className="marketing-section" aria-labelledby="faq-title">
-          <header className="marketing-section-header">
-            <p className="marketing-eyebrow">FAQ</p>
-            <h2 id="faq-title" className="marketing-section-title">
-              Questions, answered
-            </h2>
-          </header>
-          <div className="marketing-faq">
-            {FAQ.map(item => (
-              <details key={item.q} className="marketing-faq-item">
-                <summary className="marketing-faq-q">{item.q}</summary>
-                <p className="marketing-faq-a">{item.a}</p>
-              </details>
-            ))}
-          </div>
-        </section>
-
-        <section className="marketing-closing" aria-labelledby="closing-title">
-          <h2 id="closing-title" className="marketing-closing-title">
-            Ship drafts that survive the room.
+      <section className="marketing-section marketing-highlights" aria-labelledby="highlights-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">Explore</p>
+          <h2 id="highlights-title" className="marketing-section-title">
+            Three ways in
           </h2>
-          <p className="marketing-closing-sub">
-            Free while in early access. No credit card, no onboarding call.
-          </p>
+        </header>
+        <ul className="marketing-highlight-grid">
+          {HIGHLIGHTS.map(h => (
+            <li key={h.href} className="marketing-highlight-card">
+              <p className="marketing-eyebrow">{h.eyebrow}</p>
+              <h3 className="marketing-highlight-title">{h.title}</h3>
+              <p className="marketing-highlight-body">{h.body}</p>
+              <a href={h.href} className="marketing-highlight-link">
+                Read more <span aria-hidden="true">→</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="marketing-closing" aria-labelledby="closing-title">
+        <h2 id="closing-title" className="marketing-closing-title">
+          Ship drafts that survive the room.
+        </h2>
+        <p className="marketing-closing-sub">
+          Free while in early access. No credit card, no onboarding call.
+        </p>
+        <div className="marketing-cta-row">
           <button
             type="button"
             className="marketing-cta-primary marketing-closing-cta"
@@ -279,32 +137,11 @@ export function MarketingPage() {
           >
             Start writing free
           </button>
-        </section>
-      </main>
-
-      <footer className="marketing-footer">
-        <div className="marketing-footer-inner">
-          <a href="/" className="marketing-footer-logo" aria-label="Markup home">
-            <MarkupLogo height={18} />
+          <a href="/pricing" className="marketing-cta-secondary marketing-closing-cta">
+            See pricing
           </a>
-          <nav className="marketing-footer-links" aria-label="Footer">
-            <a href="/privacy" className="marketing-footer-link">Privacy</a>
-            <a href="/terms" className="marketing-footer-link">Terms</a>
-            <a href="/changelog" className="marketing-footer-link">Changelog</a>
-          </nav>
-          <span className="marketing-footer-credit">
-            A project by{' '}
-            <a
-              href="https://n3wth.com"
-              className="marketing-footer-link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              n3wth
-            </a>
-          </span>
         </div>
-      </footer>
-    </div>
+      </section>
+    </MarketingLayout>
   )
 }

--- a/src/marketing/AboutPage.tsx
+++ b/src/marketing/AboutPage.tsx
@@ -1,0 +1,132 @@
+import { MarketingLayout } from './MarketingLayout'
+import { goToLogin } from './utils'
+
+const PRINCIPLES = [
+  {
+    title: 'The draft is where decisions happen',
+    body: 'Everything before the doc is intent. Everything after is execution. If reviewers only see polished artifacts, they review the polish — not the thinking. Markup pulls the review loop forward.',
+  },
+  {
+    title: 'Agents should disagree',
+    body: 'A model that praises every draft is worse than silence. We tune agents to flag the weakest assumption first and polish last. If they say "looks great" on every turn, they stop being useful.',
+  },
+  {
+    title: 'The document is the interface',
+    body: 'Not a chat sidebar pretending to collaborate. Agents move their cursor, insert a paragraph, leave a comment. The artifact is the conversation.',
+  },
+  {
+    title: 'Writing rules, not writing style',
+    body: 'Strunk-based writing rules and a banned-word list sit in every agent prompt. No "delve." No "leverage." No marketing mush. Clarity beats voice.',
+  },
+]
+
+const TIMELINE = [
+  {
+    when: 'Late 2025',
+    what: 'Prototype: one agent reading a Tiptap doc and proposing edits.',
+  },
+  {
+    when: 'Early 2026',
+    what: 'Turn-based orchestrator. Four agents. Real-time cursors.',
+  },
+  {
+    when: 'Spring 2026',
+    what: 'Custom personas, share links, home dashboard. Early access opens.',
+  },
+  {
+    when: 'Today',
+    what: 'You, reading an About page, wondering if this will work for your PRD. It will.',
+  },
+]
+
+export function AboutPage() {
+  return (
+    <MarketingLayout pageClass="marketing-page-about" shader="mono" activePath="/about">
+      <header className="marketing-page-header about-header">
+        <p className="marketing-eyebrow">About</p>
+        <h1 className="marketing-page-title">
+          A small tool with{' '}
+          <span className="marketing-page-title-italic">strong opinions.</span>
+        </h1>
+        <p className="marketing-page-lede">
+          Markup was built to solve one problem: review is too late and too generic.
+          By the time a draft reaches a stakeholder, the interesting questions are already baked in.
+        </p>
+      </header>
+
+      <section className="about-manifesto" aria-labelledby="manifesto-title">
+        <h2 id="manifesto-title" className="about-manifesto-title">
+          We think most writing tools get AI wrong.
+        </h2>
+        <div className="about-manifesto-body">
+          <p>
+            Either they generate everything for you (so the thinking evaporates),
+            or they polish a finished draft (so nothing ever moves). Neither is review.
+          </p>
+          <p>
+            Review is a specialist looking at your work with a particular bias and saying
+            the thing you did not want to hear — while the draft is still wet enough to change.
+          </p>
+          <p>
+            Markup is the cheapest, fastest version of that loop we could build. It will not
+            replace your actual stakeholders. It will just stop you from wasting their time.
+          </p>
+        </div>
+      </section>
+
+      <section className="about-principles" aria-labelledby="principles-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">Principles</p>
+          <h2 id="principles-title" className="marketing-section-title">
+            Four convictions
+          </h2>
+        </header>
+        <ol className="about-principles-list">
+          {PRINCIPLES.map((p, i) => (
+            <li key={p.title} className="about-principle">
+              <span className="about-principle-n">{String(i + 1).padStart(2, '0')}</span>
+              <h3 className="about-principle-title">{p.title}</h3>
+              <p className="about-principle-body">{p.body}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="about-timeline" aria-labelledby="timeline-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">Timeline</p>
+          <h2 id="timeline-title" className="marketing-section-title">
+            How we got here
+          </h2>
+        </header>
+        <ul className="about-timeline-list">
+          {TIMELINE.map(t => (
+            <li key={t.when} className="about-timeline-item">
+              <span className="about-timeline-when">{t.when}</span>
+              <span className="about-timeline-what">{t.what}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="about-signoff" aria-label="Signoff">
+        <blockquote className="about-signoff-quote">
+          <p>
+            If you write PRDs, specs, RFCs, or briefs for a living — and you have
+            watched them die in review — this tool is for you.
+          </p>
+          <footer className="about-signoff-footer">
+            — Oliver, building Markup
+          </footer>
+        </blockquote>
+        <button
+          type="button"
+          className="marketing-cta-primary"
+          onClick={() => goToLogin('signup')}
+        >
+          Try it on your next draft
+        </button>
+      </section>
+    </MarketingLayout>
+  )
+}

--- a/src/marketing/AgentsPage.tsx
+++ b/src/marketing/AgentsPage.tsx
@@ -1,0 +1,174 @@
+import { MarketingLayout } from './MarketingLayout'
+import { goToLogin } from './utils'
+
+type AgentProfile = {
+  name: string
+  role: string
+  color: string
+  tagline: string
+  persona: string
+  strengths: string[]
+  tells: string[]
+  sample: string
+}
+
+const AGENTS: AgentProfile[] = [
+  {
+    name: 'Aiden',
+    role: 'Engineering',
+    color: '#30d158',
+    tagline: 'Pins vague specs to concrete interfaces and failure modes.',
+    persona:
+      'Staff engineer energy. Has shipped, has been paged, has strong feelings about retry logic. Will not sign off on a "reasonable default" without a number attached.',
+    strengths: [
+      'Finds ambiguity in interfaces',
+      'Names failure modes',
+      'Demands alternatives considered',
+      'Calls out magic thresholds',
+    ],
+    tells: ['"Say the thing."', '"For how long?"', '"What happens when this breaks?"'],
+    sample:
+      '"The service will retry" is not a design. Cap the attempts, pick an idempotency story, name the observability you want.',
+  },
+  {
+    name: 'Nova',
+    role: 'Product',
+    color: '#ff6961',
+    tagline: 'Asks who benefits, what breaks, and where adoption stalls.',
+    persona:
+      'Senior PM who has watched features die after launch. Allergic to "increase engagement" without a user and a verb. Will replay your demo as the skeptical stakeholder.',
+    strengths: [
+      'Pressure-tests user stories',
+      'Finds the edge user you forgot',
+      'Names the success metric out loud',
+      'Surfaces rollout risk early',
+    ],
+    tells: ['"Who specifically?"', '"What does this replace?"', '"What moves when this ships?"'],
+    sample:
+      '"Users want to save time" is not a thesis. Which users, saving which time, measured how, against what baseline?',
+  },
+  {
+    name: 'Lex',
+    role: 'Legal',
+    color: '#64d2ff',
+    tagline: 'Flags regulatory risk, privacy gaps, and contractual ambiguity.',
+    persona:
+      'In-house counsel with startup instincts. Will not tell you no; will tell you the five places where "probably fine" becomes "probably expensive."',
+    strengths: [
+      'Spots PII and data-handling issues',
+      'Flags terms and conditions mismatch',
+      'Catches unenforceable promises',
+      'Names jurisdictional risk',
+    ],
+    tells: [
+      '"Where does that data live?"',
+      '"Are we promising something we can\'t deliver?"',
+      '"Did we say \'guarantee\'?"',
+    ],
+    sample:
+      'Your launch copy says "unlimited." The TOS says "fair use." Pick one, or someone else will pick for you.',
+  },
+  {
+    name: 'Mira',
+    role: 'Design',
+    color: '#ffd60a',
+    tagline: 'Advocates for the user and questions complexity that hurts flow.',
+    persona:
+      'Design lead who runs usability tests weekly. Will gently dismantle your three-step wizard. Cares about the moment the user\'s face changes.',
+    strengths: [
+      'Protects the golden path',
+      'Questions density and nesting',
+      'Names the first-run moment',
+      'Flags accessibility gaps early',
+    ],
+    tells: ['"What does this feel like?"', '"Who does this exclude?"', '"Show me the empty state."'],
+    sample:
+      'Premium to whom? A CFO scanning on mobile at 7am and an analyst in a full-screen desktop context are different products. Pick one.',
+  },
+]
+
+export function AgentsPage() {
+  return (
+    <MarketingLayout pageClass="marketing-page-agents" shader="prism" activePath="/agents">
+      <header className="marketing-page-header">
+        <p className="marketing-eyebrow">Agents</p>
+        <h1 className="marketing-page-title">
+          Your <span className="marketing-page-title-italic">panel</span>, on retainer.
+        </h1>
+        <p className="marketing-page-lede">
+          Four specialists, one surface. Each has its own prompt, rhythm, and set of tells.
+          They disagree with you, and occasionally with each other. That is the point.
+        </p>
+      </header>
+
+      <div className="agents-grid">
+        {AGENTS.map(a => (
+          <article
+            key={a.name}
+            className="agents-card"
+            style={{ ['--agent-accent' as string]: a.color }}
+          >
+            <header className="agents-card-head">
+              <span className="agents-card-ring" aria-hidden="true">
+                <span className="agents-card-dot" />
+              </span>
+              <div className="agents-card-id">
+                <h2 className="agents-card-name">{a.name}</h2>
+                <p className="agents-card-role">{a.role}</p>
+              </div>
+            </header>
+            <p className="agents-card-tagline">{a.tagline}</p>
+            <p className="agents-card-persona">{a.persona}</p>
+
+            <div className="agents-card-section">
+              <p className="agents-card-label">Strengths</p>
+              <ul className="agents-card-list">
+                {a.strengths.map(s => (
+                  <li key={s}>{s}</li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="agents-card-section">
+              <p className="agents-card-label">Tells</p>
+              <ul className="agents-card-tells">
+                {a.tells.map(t => (
+                  <li key={t}>{t}</li>
+                ))}
+              </ul>
+            </div>
+
+            <blockquote className="agents-card-sample">
+              <p>{a.sample}</p>
+              <footer>
+                <span className="agents-card-sample-dot" aria-hidden="true" />
+                {a.name}, in the margin
+              </footer>
+            </blockquote>
+          </article>
+        ))}
+      </div>
+
+      <section className="agents-byo" aria-labelledby="byo-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">Custom</p>
+          <h2 id="byo-title" className="marketing-section-title">
+            Bring your own
+          </h2>
+        </header>
+        <p className="agents-byo-body">
+          Presets are a starting line. Edit the system prompt, swap the rhythm,
+          rename the agent — or add new ones up to four per session. The orchestrator
+          keeps them turn-taking so your draft never becomes a scrum.
+        </p>
+        <button
+          type="button"
+          className="marketing-cta-primary"
+          onClick={() => goToLogin('signup')}
+        >
+          Start with the defaults
+        </button>
+      </section>
+    </MarketingLayout>
+  )
+}

--- a/src/marketing/FeaturesPage.tsx
+++ b/src/marketing/FeaturesPage.tsx
@@ -1,0 +1,136 @@
+import { MarketingLayout } from './MarketingLayout'
+import { goToLogin } from './utils'
+
+const PILLARS = [
+  {
+    index: '01',
+    title: 'Four perspectives, one draft',
+    body: 'Engineering, product, legal, and design agents read the same document and push back where it matters — not a single generic voice averaging itself into nothing.',
+    note: 'Each agent has its own system prompt, temperature, and rhythm. They disagree.',
+  },
+  {
+    index: '02',
+    title: 'Ambient, not chatbot',
+    body: 'Agents live inside your document. Watch their cursors move, read their thoughts, see them edit and comment alongside you in real time — not in a side panel.',
+    note: 'ProseMirror decorations. Character-by-character typing. No floating chat window.',
+  },
+  {
+    index: '03',
+    title: 'Built to disagree',
+    body: 'Agents are tuned to push back, not praise. They surface gaps, risks, and weak assumptions before stakeholders do — and they are instructed to flag what is missing, not just polish what is there.',
+    note: '30% pushback rate baked into the orchestrator. Banned word list. Strunk rules.',
+  },
+  {
+    index: '04',
+    title: 'Ships with presets',
+    body: 'Start with PRDs, specs, briefs, or RFCs. Swap agents, rewrite personas, or bring your own. Your doc, your team — with guardrails that keep them from stepping on each other.',
+    note: 'Turn-based queue. MAX_TURNS=4. MAX_EXCHANGES=4. Self-throttling.',
+  },
+]
+
+const CAPABILITIES = [
+  { label: 'Real-time edits', detail: 'Agents insert, replace, and comment directly in Tiptap.' },
+  { label: 'Persona tuning', detail: 'Edit system prompts per agent. Save and re-use.' },
+  { label: 'Turn orchestration', detail: 'One agent speaks at a time. No shouting match.' },
+  { label: 'Heartbeat observations', detail: 'Proactive surface of TODOs, thin sections, open questions.' },
+  { label: 'Share drafts', detail: 'Viewer, commenter, or editor — by token link.' },
+  { label: 'Export anywhere', detail: 'Copy as Markdown, HTML, or plain text. No lock-in.' },
+]
+
+const FAQ = [
+  {
+    q: 'Which models do the agents use?',
+    a: 'Agents run on Google Gemini 2.5 Flash today. Each agent has its own system prompt and rhythm so their feedback reads distinct instead of averaged.',
+  },
+  {
+    q: 'Can I change the agents?',
+    a: 'Yes. You can swap presets, edit personas, or add up to four agents per session. The underlying orchestration keeps them from stepping on each other.',
+  },
+  {
+    q: 'Is my writing used to train anything?',
+    a: 'No. Your documents stay in your account. Drafts and chat are stored per-session and are not used to train models.',
+  },
+]
+
+export function FeaturesPage() {
+  return (
+    <MarketingLayout pageClass="marketing-page-features" shader="cool" activePath="/features">
+      <header className="marketing-page-header">
+        <p className="marketing-eyebrow">Features</p>
+        <h1 className="marketing-page-title">
+          Not a chatbot.{' '}
+          <span className="marketing-page-title-italic">A review panel.</span>
+        </h1>
+        <p className="marketing-page-lede">
+          Markup is built on one idea: the document is the interface. Agents live
+          inside it, edit alongside you, and disagree on purpose.
+        </p>
+      </header>
+
+      <section className="features-pillars" aria-label="Core pillars">
+        {PILLARS.map(p => (
+          <article key={p.index} className="features-pillar">
+            <span className="features-pillar-index">{p.index}</span>
+            <div className="features-pillar-body">
+              <h2 className="features-pillar-title">{p.title}</h2>
+              <p className="features-pillar-copy">{p.body}</p>
+              <p className="features-pillar-note">{p.note}</p>
+            </div>
+          </article>
+        ))}
+      </section>
+
+      <section className="features-capabilities" aria-labelledby="capabilities-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">Capabilities</p>
+          <h2 id="capabilities-title" className="marketing-section-title">
+            What you get on day one
+          </h2>
+        </header>
+        <ul className="features-cap-grid">
+          {CAPABILITIES.map(c => (
+            <li key={c.label} className="features-cap-item">
+              <span className="features-cap-label">{c.label}</span>
+              <span className="features-cap-detail">{c.detail}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="features-faq" aria-labelledby="features-faq-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">FAQ</p>
+          <h2 id="features-faq-title" className="marketing-section-title">
+            Common questions
+          </h2>
+        </header>
+        <div className="marketing-faq">
+          {FAQ.map(item => (
+            <details key={item.q} className="marketing-faq-item">
+              <summary className="marketing-faq-q">{item.q}</summary>
+              <p className="marketing-faq-a">{item.a}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      <section className="marketing-closing" aria-labelledby="features-closing-title">
+        <h2 id="features-closing-title" className="marketing-closing-title">
+          Open a draft. Invite the panel.
+        </h2>
+        <div className="marketing-cta-row">
+          <button
+            type="button"
+            className="marketing-cta-primary marketing-closing-cta"
+            onClick={() => goToLogin('signup')}
+          >
+            Start writing free
+          </button>
+          <a href="/agents" className="marketing-cta-secondary marketing-closing-cta">
+            Meet the agents
+          </a>
+        </div>
+      </section>
+    </MarketingLayout>
+  )
+}

--- a/src/marketing/MarketingLayout.tsx
+++ b/src/marketing/MarketingLayout.tsx
@@ -1,0 +1,159 @@
+import { lazy, Suspense, type ReactNode } from 'react'
+import { MarkupLogo } from '../MarkupLogo'
+import { goToLogin } from './utils'
+
+const ColorPanels = lazy(() =>
+  import('@paper-design/shaders-react').then(m => ({ default: m.ColorPanels }))
+)
+
+type ShaderVariant = 'warm' | 'cool' | 'prism' | 'mono' | 'sunset' | 'none'
+
+const SHADER_PALETTES: Record<Exclude<ShaderVariant, 'none'>, string[]> = {
+  warm: ['#FF9D00', '#FD4F30', '#809BFF', '#6D2EFF', '#333AFF', '#F15CFF', '#FFD557'],
+  cool: ['#64d2ff', '#5e5ce6', '#30d158', '#809BFF', '#bf5af2', '#0a84ff'],
+  prism: ['#ff6961', '#ffd60a', '#30d158', '#64d2ff', '#bf5af2'],
+  mono: ['#ececee', '#787878', '#525252', '#a3a3a3', '#2a2a2a'],
+  sunset: ['#ff9d00', '#ff6961', '#f15cff', '#6d2eff', '#333aff'],
+}
+
+type NavLink = { href: string; label: string }
+
+const DEFAULT_NAV: NavLink[] = [
+  { href: '/features', label: 'Features' },
+  { href: '/use-cases', label: 'Use cases' },
+  { href: '/agents', label: 'Agents' },
+  { href: '/pricing', label: 'Pricing' },
+  { href: '/about', label: 'About' },
+]
+
+type Props = {
+  children: ReactNode
+  /** Class appended to the page wrapper so each page can layer distinct styling */
+  pageClass: string
+  /** Named shader palette or 'none' to disable */
+  shader?: ShaderVariant
+  /** Current pathname — used to mark active nav link */
+  activePath?: string
+  /** Override shader intensity (0–1). Defaults to 0.45 */
+  shaderOpacity?: number
+}
+
+export function MarketingLayout({
+  children,
+  pageClass,
+  shader = 'warm',
+  activePath,
+  shaderOpacity = 0.45,
+}: Props) {
+  const current = activePath ?? (typeof window !== 'undefined' ? window.location.pathname : '/')
+
+  return (
+    <div className={`marketing-page ${pageClass}`}>
+      {shader !== 'none' && (
+        <div className="marketing-shader" aria-hidden="true">
+          <Suspense fallback={null}>
+            <ColorPanels
+              speed={0.35}
+              scale={1.4}
+              density={2}
+              angle1={0}
+              angle2={0}
+              length={1.2}
+              edges={false}
+              blur={0}
+              fadeIn={1}
+              fadeOut={0.5}
+              gradient={0}
+              rotation={0}
+              offsetX={0}
+              offsetY={0}
+              maxPixelCount={1920 * 1080}
+              minPixelRatio={1}
+              colors={SHADER_PALETTES[shader]}
+              colorBack="#00000000"
+              style={{
+                height: '100%',
+                width: '100%',
+                mixBlendMode: 'screen',
+                opacity: shaderOpacity,
+              }}
+            />
+          </Suspense>
+        </div>
+      )}
+
+      <nav className="marketing-nav" aria-label="Primary">
+        <a href="/" className="marketing-nav-logo" aria-label="Markup home">
+          <MarkupLogo height={20} />
+        </a>
+        <div className="marketing-nav-links">
+          {DEFAULT_NAV.map(link => (
+            <a
+              key={link.href}
+              href={link.href}
+              className={`marketing-nav-link ${current === link.href ? 'is-active' : ''}`}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+        <div className="marketing-nav-actions">
+          <button
+            type="button"
+            className="marketing-nav-link marketing-nav-signin"
+            onClick={() => goToLogin('signin')}
+          >
+            Sign in
+          </button>
+          <button
+            type="button"
+            className="marketing-cta-primary marketing-nav-cta"
+            onClick={() => goToLogin('signup')}
+          >
+            Get started
+          </button>
+        </div>
+      </nav>
+
+      <main className="marketing-main">{children}</main>
+
+      <footer className="marketing-footer">
+        <div className="marketing-footer-inner">
+          <a href="/" className="marketing-footer-logo" aria-label="Markup home">
+            <MarkupLogo height={18} />
+          </a>
+          <nav className="marketing-footer-columns" aria-label="Footer">
+            <div className="marketing-footer-col">
+              <span className="marketing-footer-heading">Product</span>
+              <a href="/features" className="marketing-footer-link">Features</a>
+              <a href="/use-cases" className="marketing-footer-link">Use cases</a>
+              <a href="/agents" className="marketing-footer-link">Agents</a>
+              <a href="/pricing" className="marketing-footer-link">Pricing</a>
+            </div>
+            <div className="marketing-footer-col">
+              <span className="marketing-footer-heading">Company</span>
+              <a href="/about" className="marketing-footer-link">About</a>
+              <a href="/changelog" className="marketing-footer-link">Changelog</a>
+            </div>
+            <div className="marketing-footer-col">
+              <span className="marketing-footer-heading">Legal</span>
+              <a href="/privacy" className="marketing-footer-link">Privacy</a>
+              <a href="/terms" className="marketing-footer-link">Terms</a>
+            </div>
+          </nav>
+          <span className="marketing-footer-credit">
+            A project by{' '}
+            <a
+              href="https://n3wth.com"
+              className="marketing-footer-link"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              n3wth
+            </a>
+          </span>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/marketing/PricingPage.tsx
+++ b/src/marketing/PricingPage.tsx
@@ -1,0 +1,190 @@
+import { MarketingLayout } from './MarketingLayout'
+import { goToLogin } from './utils'
+
+type Tier = {
+  name: string
+  price: string
+  cadence: string
+  description: string
+  featured?: boolean
+  cta: { label: string; href?: string; mode?: 'signin' | 'signup' }
+  features: string[]
+}
+
+const TIERS: Tier[] = [
+  {
+    name: 'Free',
+    price: '$0',
+    cadence: 'while in early access',
+    description: 'Everything you need to try the review panel on a real draft.',
+    cta: { label: 'Start free', mode: 'signup' },
+    features: [
+      'Up to 4 agents per session',
+      'All built-in presets (Aiden, Nova, Lex, Mira)',
+      'Unlimited personal drafts',
+      'Share links (viewer + commenter)',
+      'Export as Markdown or HTML',
+    ],
+  },
+  {
+    name: 'Pro',
+    price: '$18',
+    cadence: 'per month',
+    description: 'For writers who live in Markup. Higher limits, custom agents.',
+    featured: true,
+    cta: { label: 'Coming soon', mode: 'signup' },
+    features: [
+      'Everything in Free',
+      'Custom agents + shared persona library',
+      'Higher per-session turn limits',
+      'Editor share-link role + branded share page',
+      'Priority model routing',
+      'Email support',
+    ],
+  },
+  {
+    name: 'Team',
+    price: 'Custom',
+    cadence: 'contact us',
+    description: 'Shared workspaces, SSO, admin controls. Real infrastructure for real teams.',
+    cta: { label: 'Contact sales', href: 'mailto:oliver@newth.ai?subject=Markup%20Team' },
+    features: [
+      'Everything in Pro',
+      'Shared workspaces + seats',
+      'SSO (Google, Okta)',
+      'Admin roles + audit log',
+      'Data residency options',
+      'Dedicated Slack channel',
+    ],
+  },
+]
+
+const COMPARE = [
+  { row: 'Agents per session', cells: ['4', '4 + custom', '4 + custom'] },
+  { row: 'Turns per agent', cells: ['4', '10', '10+'] },
+  { row: 'Shared workspaces', cells: ['—', '—', 'Yes'] },
+  { row: 'SSO', cells: ['—', '—', 'Yes'] },
+  { row: 'Admin log', cells: ['—', '—', 'Yes'] },
+  { row: 'Support', cells: ['Community', 'Email', 'Dedicated'] },
+]
+
+const FAQ = [
+  {
+    q: 'Is Markup really free right now?',
+    a: 'Yes. While in early access, the full product is free. We’ll give you at least 30 days notice before introducing paid plans.',
+  },
+  {
+    q: 'Do I need a credit card to start?',
+    a: 'No. Sign in with Google or email and start drafting. There is no trial timer.',
+  },
+  {
+    q: 'Can I self-host?',
+    a: 'Not today. The orchestrator, agents, and document store are tightly coupled. Reach out if you have a real need.',
+  },
+]
+
+function ctaHandler(cta: Tier['cta']) {
+  if (cta.href) {
+    return () => {
+      window.location.href = cta.href!
+    }
+  }
+  return () => goToLogin(cta.mode ?? 'signup')
+}
+
+export function PricingPage() {
+  return (
+    <MarketingLayout pageClass="marketing-page-pricing" shader="prism" activePath="/pricing">
+      <header className="marketing-page-header">
+        <p className="marketing-eyebrow">Pricing</p>
+        <h1 className="marketing-page-title">
+          Simple while we earn it.
+        </h1>
+        <p className="marketing-page-lede">
+          Free while in early access. Paid tiers below are directional — they give a
+          sense of where we&apos;re going, not what you owe today.
+        </p>
+      </header>
+
+      <section className="pricing-tiers" aria-label="Plans">
+        {TIERS.map(tier => (
+          <article
+            key={tier.name}
+            className={`pricing-tier ${tier.featured ? 'is-featured' : ''}`}
+          >
+            {tier.featured && <span className="pricing-tier-badge">Most loved</span>}
+            <header className="pricing-tier-head">
+              <h2 className="pricing-tier-name">{tier.name}</h2>
+              <div className="pricing-tier-price">
+                <span className="pricing-tier-amount">{tier.price}</span>
+                <span className="pricing-tier-cadence">{tier.cadence}</span>
+              </div>
+              <p className="pricing-tier-desc">{tier.description}</p>
+            </header>
+            <ul className="pricing-tier-features">
+              {tier.features.map(f => (
+                <li key={f}>
+                  <span className="pricing-check" aria-hidden="true">✓</span>
+                  {f}
+                </li>
+              ))}
+            </ul>
+            <button
+              type="button"
+              className={
+                tier.featured
+                  ? 'marketing-cta-primary pricing-tier-cta'
+                  : 'marketing-cta-secondary pricing-tier-cta'
+              }
+              onClick={ctaHandler(tier.cta)}
+            >
+              {tier.cta.label}
+            </button>
+          </article>
+        ))}
+      </section>
+
+      <section className="pricing-compare" aria-labelledby="compare-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">Compare</p>
+          <h2 id="compare-title" className="marketing-section-title">
+            Side-by-side
+          </h2>
+        </header>
+        <div className="pricing-compare-table">
+          <div className="pricing-compare-head" role="row">
+            <span className="pricing-compare-cell pricing-compare-rowlabel" />
+            <span className="pricing-compare-cell">Free</span>
+            <span className="pricing-compare-cell">Pro</span>
+            <span className="pricing-compare-cell">Team</span>
+          </div>
+          {COMPARE.map(r => (
+            <div className="pricing-compare-row" role="row" key={r.row}>
+              <span className="pricing-compare-cell pricing-compare-rowlabel">{r.row}</span>
+              {r.cells.map((c, i) => (
+                <span key={i} className="pricing-compare-cell">{c}</span>
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="pricing-faq" aria-labelledby="pricing-faq-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">FAQ</p>
+          <h2 id="pricing-faq-title" className="marketing-section-title">
+            Fine print, minus the fine
+          </h2>
+        </header>
+        <div className="marketing-faq">
+          {FAQ.map(item => (
+            <details key={item.q} className="marketing-faq-item">
+              <summary className="marketing-faq-q">{item.q}</summary>
+              <p className="marketing-faq-a">{item.a}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+    </MarketingLayout>
+  )
+}

--- a/src/marketing/UseCasesPage.tsx
+++ b/src/marketing/UseCasesPage.tsx
@@ -1,0 +1,167 @@
+import { MarketingLayout } from './MarketingLayout'
+import { goToLogin } from './utils'
+
+type Scenario = {
+  slug: string
+  label: string
+  headline: string
+  summary: string
+  before: string
+  after: string
+  panel: { name: string; color: string; note: string }[]
+}
+
+const SCENARIOS: Scenario[] = [
+  {
+    slug: 'prd',
+    label: 'PRD',
+    headline: 'A PRD that survives engineering review',
+    summary:
+      'Product requirements live or die by the questions you did not think to ask. Markup asks them before your tech lead does.',
+    before: 'The user can save drafts automatically so they don\'t lose work.',
+    after:
+      'Aiden: "Saved where? Local storage has a 5MB ceiling. Saved how often? Every keystroke will burn quota. What happens on offline → online reconnect with stale local state?"',
+    panel: [
+      { name: 'Aiden', color: '#30d158', note: 'Hunts ambiguity and failure modes.' },
+      { name: 'Nova', color: '#ff6961', note: 'Asks which user and why now.' },
+    ],
+  },
+  {
+    slug: 'spec',
+    label: 'Spec',
+    headline: 'A technical spec with honest failure modes',
+    summary:
+      'Specs that only describe the happy path are fiction. Markup forces you to write down what breaks.',
+    before: 'The service will retry failed requests with exponential backoff.',
+    after:
+      'Aiden: "For how long? What\'s the cap? What happens after the cap? Is the retry idempotent? Does the caller see the first error or the last? Say the thing."',
+    panel: [
+      { name: 'Aiden', color: '#30d158', note: 'Probes edge cases.' },
+      { name: 'Lex', color: '#64d2ff', note: 'Flags data and privacy implications.' },
+    ],
+  },
+  {
+    slug: 'brief',
+    label: 'Design brief',
+    headline: 'A brief that respects the user',
+    summary:
+      'Briefs that skip context force designers to guess. Markup pushes you to name the user, the job, and the constraint.',
+    before: 'We need a clean, modern dashboard that feels premium.',
+    after:
+      'Mira: "Premium to whom? A CFO scanning at 7am on mobile, or an analyst in a full-screen desktop context? Those are different products. Pick one."',
+    panel: [
+      { name: 'Mira', color: '#ffd60a', note: 'Advocates for the actual user.' },
+      { name: 'Nova', color: '#ff6961', note: 'Ties visual to business outcome.' },
+    ],
+  },
+  {
+    slug: 'rfc',
+    label: 'RFC',
+    headline: 'An RFC that invites real disagreement',
+    summary:
+      'RFCs often ship with the decision pre-baked. Markup forces the alternatives you dismissed back onto the page.',
+    before: 'We propose moving to gRPC for all internal services.',
+    after:
+      'Aiden: "You\'re proposing a migration. What did you consider and reject? HTTP/2 + JSON? Connect-Web? Without the rejected options, this reads like a mandate, not a proposal."',
+    panel: [
+      { name: 'Aiden', color: '#30d158', note: 'Demands alternatives.' },
+      { name: 'Lex', color: '#64d2ff', note: 'Questions vendor lock-in and contracts.' },
+    ],
+  },
+  {
+    slug: 'launch',
+    label: 'Launch plan',
+    headline: 'A launch plan with the risk written down',
+    summary:
+      'Launch plans that only describe success are marketing, not plans. Markup names what you will do when the demo flops.',
+    before: 'We will announce on Tuesday, push to Product Hunt on Wednesday.',
+    after:
+      'Nova: "What happens if the top comment on PH is a known issue? What\'s your response tree? Who owns it? PH traffic is front-loaded — a slow first hour kills the rest."',
+    panel: [
+      { name: 'Nova', color: '#ff6961', note: 'Plays devil\'s advocate for rollout risk.' },
+      { name: 'Lex', color: '#64d2ff', note: 'Catches claims that will need caveats.' },
+    ],
+  },
+]
+
+export function UseCasesPage() {
+  return (
+    <MarketingLayout pageClass="marketing-page-usecases" shader="sunset" activePath="/use-cases">
+      <header className="marketing-page-header">
+        <p className="marketing-eyebrow">Use cases</p>
+        <h1 className="marketing-page-title">
+          Documents that{' '}
+          <span className="marketing-page-title-italic">live or die</span> in review.
+        </h1>
+        <p className="marketing-page-lede">
+          Every doc below has the same problem: the feedback that matters arrives too late.
+          Here&apos;s how Markup moves that feedback into the draft.
+        </p>
+      </header>
+
+      <nav className="usecases-jump" aria-label="Jump to scenario">
+        {SCENARIOS.map(s => (
+          <a key={s.slug} href={`#${s.slug}`} className="usecases-jump-link">
+            {s.label}
+          </a>
+        ))}
+      </nav>
+
+      <div className="usecases-list">
+        {SCENARIOS.map((s, i) => (
+          <article
+            key={s.slug}
+            id={s.slug}
+            className={`usecases-scenario ${i % 2 === 1 ? 'is-reverse' : ''}`}
+          >
+            <div className="usecases-scenario-copy">
+              <p className="marketing-eyebrow">{s.label}</p>
+              <h2 className="usecases-scenario-title">{s.headline}</h2>
+              <p className="usecases-scenario-summary">{s.summary}</p>
+              <ul className="usecases-panel" aria-label="Panel">
+                {s.panel.map(p => (
+                  <li key={p.name} className="usecases-panel-item">
+                    <span
+                      className="usecases-panel-dot"
+                      style={{ background: p.color }}
+                      aria-hidden="true"
+                    />
+                    <span className="usecases-panel-name">{p.name}</span>
+                    <span className="usecases-panel-note">{p.note}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="usecases-scenario-demo">
+              <div className="usecases-demo-line usecases-demo-before">
+                <span className="usecases-demo-label">Draft</span>
+                <p>{s.before}</p>
+              </div>
+              <div className="usecases-demo-arrow" aria-hidden="true">↓</div>
+              <div className="usecases-demo-line usecases-demo-after">
+                <span className="usecases-demo-label">In the margin</span>
+                <p>{s.after}</p>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <section className="marketing-closing">
+        <h2 className="marketing-closing-title">
+          Your draft, your panel.
+        </h2>
+        <p className="marketing-closing-sub">
+          Paste in a doc. Pick your reviewers. See what you missed.
+        </p>
+        <button
+          type="button"
+          className="marketing-cta-primary marketing-closing-cta"
+          onClick={() => goToLogin('signup')}
+        >
+          Try Markup free
+        </button>
+      </section>
+    </MarketingLayout>
+  )
+}

--- a/src/marketing/utils.ts
+++ b/src/marketing/utils.ts
@@ -1,0 +1,4 @@
+export function goToLogin(mode: 'signin' | 'signup' = 'signin') {
+  const target = mode === 'signup' ? '/?login=1&mode=signup' : '/?login=1'
+  window.location.href = target
+}


### PR DESCRIPTION
## Summary
Refinery merge for mk-wisp-vix (worker: cheedo, source: mk-rn7). Expands marketing site into multi-page layout — features, pricing, about, use cases, agents — with shared MarketingLayout.

Pre-merge validation (all ✓):
- Build (TypeScript + Vite)
- 539/539 tests
- Lint

## Test plan
- [ ] CI status checks pass
- [ ] Merge lands on main
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
