### PR TITLE
fix(routing): rewrite SPA routes to index.html to fix 404s (mk-i44)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,17 @@
 {
   "rewrites": [
     { "source": "/s/:path*", "destination": "/index.html" },
+    { "source": "/share/:path*", "destination": "/index.html" },
     { "source": "/privacy", "destination": "/index.html" },
     { "source": "/terms", "destination": "/index.html" },
-    { "source": "/changelog", "destination": "/index.html" }
+    { "source": "/changelog", "destination": "/index.html" },
+    { "source": "/features", "destination": "/index.html" },
+    { "source": "/pricing", "destination": "/index.html" },
+    { "source": "/about", "destination": "/index.html" },
+    { "source": "/use-cases", "destination": "/index.html" },
+    { "source": "/agents", "destination": "/index.html" },
+    { "source": "/login", "destination": "/index.html" },
+    { "source": "/referrals", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary
Refinery merge for mk-wisp-d5h (worker: cheedo, source: mk-i44). Fixes production 404s on logged-out marketing pages by adding `vercel.json` rewrites for the new multi-page routes (features, pricing, about, use-cases, agents, login, referrals, share).

Pre-merge validation (all ✓):
- Build (TypeScript + Vite)
- 539/539 tests
- Lint

## Test plan
- [ ] CI status checks pass
- [ ] Logged-out /features, /pricing etc return 200 on Vercel preview
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
