### PR TITLE
feat(marketing): add features section — 3 value prop cards (mk-1bv)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7138,6 +7138,71 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
   color: var(--text-tertiary);
 }
 
+/* Home features section — exactly 3 items, 3-col grid, no orphan */
+.marketing-features-section {
+  padding: 96px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.marketing-features-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.marketing-features-card {
+  padding: 28px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  transition: border-color var(--duration-fast) ease, background var(--duration-fast) ease;
+}
+
+.marketing-features-card:hover {
+  background: var(--surface-2);
+  border-color: var(--border-default);
+}
+
+.marketing-features-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--surface-3);
+  color: var(--text-secondary);
+  margin-bottom: 20px;
+  flex-shrink: 0;
+}
+
+.marketing-features-title {
+  margin: 0 0 10px;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.marketing-features-body {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 820px) {
+  .marketing-features-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Focus styles — keyboard nav */
 .marketing-page :focus-visible {
   outline: 2px solid var(--text-primary);

--- a/src/marketing/FeaturesSection.tsx
+++ b/src/marketing/FeaturesSection.tsx
@@ -1,0 +1,46 @@
+import { Sparkles, Users, FileText } from 'lucide-react'
+
+const FEATURES = [
+  {
+    icon: Sparkles,
+    title: 'AI Writing Assistant',
+    body: 'Four specialist agents — engineering, product, legal, design — read your draft and push back in real time. Not a generic spell-checker. A standing review panel.',
+  },
+  {
+    icon: Users,
+    title: 'Real-time Collaboration',
+    body: 'Watch agent cursors move through your document as they think, edit, and comment alongside you. Every suggestion lands in the draft, not a separate thread.',
+  },
+  {
+    icon: FileText,
+    title: 'Google Docs Integration',
+    body: 'Export to Markdown, HTML, or plain text in one click. No lock-in, no format gymnastics — your doc stays yours.',
+  },
+]
+
+export function FeaturesSection() {
+  return (
+    <section className="marketing-section marketing-features-section" aria-labelledby="features-section-title">
+      <header className="marketing-section-header">
+        <p className="marketing-eyebrow">Why Markup</p>
+        <h2 id="features-section-title" className="marketing-section-title">
+          Everything your draft needs
+        </h2>
+      </header>
+      <ul className="marketing-features-grid">
+        {FEATURES.map(f => {
+          const Icon = f.icon
+          return (
+            <li key={f.title} className="marketing-features-card">
+              <span className="marketing-features-icon" aria-hidden="true">
+                <Icon size={22} strokeWidth={1.5} />
+              </span>
+              <h3 className="marketing-features-title">{f.title}</h3>
+              <p className="marketing-features-body">{f.body}</p>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
Refinery merge for mk-wisp-iwj (worker: cheedo, source: mk-1bv). Adds 3-column features section to home marketing page with AI Writing Assistant, Real-time Collaboration, and Google Docs Integration cards.

Pre-merge validation (all ✓):
- Build
- 539/539 tests
- Lint

## Test plan
- [ ] CI status checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
