### PR TITLE
feat(marketing): smooth page transitions and SPA routing (mk-3p2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.5",
+        "react-router-dom": "^7.14.2",
         "simplex-noise": "^4.0.3",
         "streamdown": "^2.5.0",
         "zod": "^4.3.6"
@@ -14020,6 +14021,57 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -14489,6 +14541,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.2",
     "simplex-noise": "^4.0.3",
     "streamdown": "^2.5.0",
     "zod": "^4.3.6"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,7 @@ import { loadUserSettings, saveGeminiApiKey } from './lib/settings-store'
 
 // Lazy-loaded components (not needed on initial render)
 const LoginPage = lazy(() => import('./LoginPage').then(m => ({ default: m.LoginPage })))
-const MarketingPage = lazy(() => import('./MarketingPage').then(m => ({ default: m.MarketingPage })))
-const FeaturesPage = lazy(() => import('./marketing/FeaturesPage').then(m => ({ default: m.FeaturesPage })))
-const PricingPage = lazy(() => import('./marketing/PricingPage').then(m => ({ default: m.PricingPage })))
-const AboutPage = lazy(() => import('./marketing/AboutPage').then(m => ({ default: m.AboutPage })))
-const UseCasesPage = lazy(() => import('./marketing/UseCasesPage').then(m => ({ default: m.UseCasesPage })))
-const AgentsPage = lazy(() => import('./marketing/AgentsPage').then(m => ({ default: m.AgentsPage })))
+const MarketingRouter = lazy(() => import('./marketing/MarketingRouter').then(m => ({ default: m.MarketingRouter })))
 const LegalPage = lazy(() => import('./LegalPage').then(m => ({ default: m.LegalPage })))
 const ReferralsPage = lazy(() => import('./ReferralsPage').then(m => ({ default: m.ReferralsPage })))
 const ChangelogPage = lazy(() => import('./ChangelogPage').then(m => ({ default: m.ChangelogPage })))
@@ -489,12 +484,16 @@ function App() {
   if (window.location.pathname === '/terms') return <Suspense><LegalPage page="terms" /></Suspense>
   if (window.location.pathname === '/changelog') return <Suspense><ChangelogPage /></Suspense>
 
-  // Marketing sub-pages -- always accessible, even to signed-in users
-  if (window.location.pathname === '/features') return <Suspense><FeaturesPage /></Suspense>
-  if (window.location.pathname === '/pricing') return <Suspense><PricingPage /></Suspense>
-  if (window.location.pathname === '/about') return <Suspense><AboutPage /></Suspense>
-  if (window.location.pathname === '/use-cases') return <Suspense><UseCasesPage /></Suspense>
-  if (window.location.pathname === '/agents') return <Suspense><AgentsPage /></Suspense>
+  // Marketing pages -- SPA-routed with smooth transitions.
+  // Sub-pages are accessible to signed-in users too (browsing from the app).
+  // On localhost, '/' falls through to the app; other marketing paths still render.
+  const MARKETING_PATHS = ['/features', '/pricing', '/about', '/use-cases', '/agents']
+  const isHomePath = window.location.pathname === '/'
+  const isMarketingSubPath = MARKETING_PATHS.includes(window.location.pathname)
+  const showMarketing = isMarketingSubPath || (isHomePath && !isLocalhost && !user)
+  if (showMarketing) {
+    return <Suspense fallback={null}><MarketingRouter /></Suspense>
+  }
 
   // Referrals page -- requires a signed-in user (or localhost).
   // Uses full-page nav on close to match the legal-pages pattern so the
@@ -521,10 +520,7 @@ function App() {
     return <Suspense><LoginPage /></Suspense>
   }
 
-  // Unauthenticated visitors on non-localhost -> marketing landing page
-  if (!isLocalhost && !user) {
-    return <Suspense><MarketingPage /></Suspense>
-  }
+  // Unauthenticated visitors on non-localhost -> marketing landing page (already handled above by MarketingRouter)
 
   const showMobileSidebar = isMobile && mobileSidebarOpen
   const sidebarColumnStyle = isMobile

--- a/src/MarketingPage.tsx
+++ b/src/MarketingPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { MarketingLayout } from './marketing/MarketingLayout'
 import { goToLogin } from './marketing/utils'
 
@@ -70,9 +71,9 @@ export function MarketingPage() {
           >
             Start writing free
           </button>
-          <a href="/features" className="marketing-cta-secondary">
+          <Link to="/features" className="marketing-cta-secondary">
             See how it works
-          </a>
+          </Link>
         </div>
 
         <ul className="marketing-agent-row" aria-label="Your review panel">
@@ -114,9 +115,9 @@ export function MarketingPage() {
               <p className="marketing-eyebrow">{h.eyebrow}</p>
               <h3 className="marketing-highlight-title">{h.title}</h3>
               <p className="marketing-highlight-body">{h.body}</p>
-              <a href={h.href} className="marketing-highlight-link">
+              <Link to={h.href} className="marketing-highlight-link">
                 Read more <span aria-hidden="true">→</span>
-              </a>
+              </Link>
             </li>
           ))}
         </ul>
@@ -137,9 +138,9 @@ export function MarketingPage() {
           >
             Start writing free
           </button>
-          <a href="/pricing" className="marketing-cta-secondary marketing-closing-cta">
+          <Link to="/pricing" className="marketing-cta-secondary marketing-closing-cta">
             See pricing
-          </a>
+          </Link>
         </div>
       </section>
     </MarketingLayout>

--- a/src/marketing/FeaturesPage.tsx
+++ b/src/marketing/FeaturesPage.tsx
@@ -1,4 +1,5 @@
 import { Sparkles, Users, FileText, Brain, Download } from 'lucide-react'
+import { Link } from 'react-router-dom'
 import { MarketingLayout } from './MarketingLayout'
 import { goToLogin } from './utils'
 
@@ -178,9 +179,9 @@ export function FeaturesPage() {
           >
             Start writing free
           </button>
-          <a href="/agents" className="marketing-cta-secondary marketing-closing-cta">
+          <Link to="/agents" className="marketing-cta-secondary marketing-closing-cta">
             Meet the agents
-          </a>
+          </Link>
         </div>
       </section>
     </MarketingLayout>

--- a/src/marketing/MarketingLayout.tsx
+++ b/src/marketing/MarketingLayout.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, type ReactNode } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 import { MarkupLogo } from '../MarkupLogo'
 import { goToLogin } from './utils'
 
@@ -16,25 +17,22 @@ const SHADER_PALETTES: Record<Exclude<ShaderVariant, 'none'>, string[]> = {
   sunset: ['#ff9d00', '#ff6961', '#f15cff', '#6d2eff', '#333aff'],
 }
 
-type NavLink = { href: string; label: string }
+type NavLink = { to: string; label: string }
 
 const DEFAULT_NAV: NavLink[] = [
-  { href: '/features', label: 'Features' },
-  { href: '/use-cases', label: 'Use cases' },
-  { href: '/agents', label: 'Agents' },
-  { href: '/pricing', label: 'Pricing' },
-  { href: '/about', label: 'About' },
+  { to: '/features', label: 'Features' },
+  { to: '/use-cases', label: 'Use cases' },
+  { to: '/agents', label: 'Agents' },
+  { to: '/pricing', label: 'Pricing' },
+  { to: '/about', label: 'About' },
 ]
 
 type Props = {
   children: ReactNode
-  /** Class appended to the page wrapper so each page can layer distinct styling */
   pageClass: string
-  /** Named shader palette or 'none' to disable */
   shader?: ShaderVariant
-  /** Current pathname — used to mark active nav link */
+  /** @deprecated active state is now derived from useLocation */
   activePath?: string
-  /** Override shader intensity (0–1). Defaults to 0.45 */
   shaderOpacity?: number
 }
 
@@ -42,10 +40,10 @@ export function MarketingLayout({
   children,
   pageClass,
   shader = 'warm',
-  activePath,
   shaderOpacity = 0.45,
 }: Props) {
-  const current = activePath ?? (typeof window !== 'undefined' ? window.location.pathname : '/')
+  const location = useLocation()
+  const current = location.pathname
 
   return (
     <div className={`marketing-page ${pageClass}`}>
@@ -83,18 +81,18 @@ export function MarketingLayout({
       )}
 
       <nav className="marketing-nav" aria-label="Primary">
-        <a href="/" className="marketing-nav-logo" aria-label="Markup home">
+        <Link to="/" className="marketing-nav-logo" aria-label="Markup home">
           <MarkupLogo height={20} />
-        </a>
+        </Link>
         <div className="marketing-nav-links">
           {DEFAULT_NAV.map(link => (
-            <a
-              key={link.href}
-              href={link.href}
-              className={`marketing-nav-link ${current === link.href ? 'is-active' : ''}`}
+            <Link
+              key={link.to}
+              to={link.to}
+              className={`marketing-nav-link ${current === link.to ? 'is-active' : ''}`}
             >
               {link.label}
-            </a>
+            </Link>
           ))}
         </div>
         <div className="marketing-nav-actions">
@@ -119,20 +117,20 @@ export function MarketingLayout({
 
       <footer className="marketing-footer">
         <div className="marketing-footer-inner">
-          <a href="/" className="marketing-footer-logo" aria-label="Markup home">
+          <Link to="/" className="marketing-footer-logo" aria-label="Markup home">
             <MarkupLogo height={18} />
-          </a>
+          </Link>
           <nav className="marketing-footer-columns" aria-label="Footer">
             <div className="marketing-footer-col">
               <span className="marketing-footer-heading">Product</span>
-              <a href="/features" className="marketing-footer-link">Features</a>
-              <a href="/use-cases" className="marketing-footer-link">Use cases</a>
-              <a href="/agents" className="marketing-footer-link">Agents</a>
-              <a href="/pricing" className="marketing-footer-link">Pricing</a>
+              <Link to="/features" className="marketing-footer-link">Features</Link>
+              <Link to="/use-cases" className="marketing-footer-link">Use cases</Link>
+              <Link to="/agents" className="marketing-footer-link">Agents</Link>
+              <Link to="/pricing" className="marketing-footer-link">Pricing</Link>
             </div>
             <div className="marketing-footer-col">
               <span className="marketing-footer-heading">Company</span>
-              <a href="/about" className="marketing-footer-link">About</a>
+              <Link to="/about" className="marketing-footer-link">About</Link>
               <a href="/changelog" className="marketing-footer-link">Changelog</a>
             </div>
             <div className="marketing-footer-col">

--- a/src/marketing/MarketingRouter.tsx
+++ b/src/marketing/MarketingRouter.tsx
@@ -1,0 +1,68 @@
+import { lazy, Suspense } from 'react'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { AnimatePresence, motion } from 'framer-motion'
+
+const MarketingPage = lazy(() =>
+  import('../MarketingPage').then(m => ({ default: m.MarketingPage }))
+)
+const FeaturesPage = lazy(() =>
+  import('./FeaturesPage').then(m => ({ default: m.FeaturesPage }))
+)
+const PricingPage = lazy(() =>
+  import('./PricingPage').then(m => ({ default: m.PricingPage }))
+)
+const AboutPage = lazy(() =>
+  import('./AboutPage').then(m => ({ default: m.AboutPage }))
+)
+const UseCasesPage = lazy(() =>
+  import('./UseCasesPage').then(m => ({ default: m.UseCasesPage }))
+)
+const AgentsPage = lazy(() =>
+  import('./AgentsPage').then(m => ({ default: m.AgentsPage }))
+)
+
+const variants = {
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -8 },
+}
+
+const transition = { duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }
+
+function AnimatedRoutes() {
+  const location = useLocation()
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.div
+        key={location.pathname}
+        variants={variants}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        transition={transition}
+        style={{ width: '100%' }}
+      >
+        <Suspense fallback={null}>
+          <Routes location={location}>
+            <Route path="/" element={<MarketingPage />} />
+            <Route path="/features" element={<FeaturesPage />} />
+            <Route path="/pricing" element={<PricingPage />} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/use-cases" element={<UseCasesPage />} />
+            <Route path="/agents" element={<AgentsPage />} />
+          </Routes>
+        </Suspense>
+      </motion.div>
+    </AnimatePresence>
+  )
+}
+
+export function MarketingRouter() {
+  return (
+    <BrowserRouter>
+      <AnimatedRoutes />
+    </BrowserRouter>
+  )
+}
+


### PR DESCRIPTION
Refinery merge for mk-wisp-aht (worker: morsov, source: mk-3p2). Adds react-router-dom and MarketingRouter for client-side transitions between marketing pages. Rebased onto latest main by refinery.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
