### PR TITLE
feat(marketing): flesh out /features page with detailed breakdown (mk-ee8)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7593,6 +7593,40 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
    Features page
    ============================================================ */
 
+.features-core-grid {
+  padding: 80px 0 96px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.features-grid-5 {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+/* Last 2 items span to center when 5 items in a 3-col grid */
+.features-grid-5 > li:nth-child(4) {
+  grid-column: 1 / 2;
+}
+
+.features-grid-5 > li:nth-child(5) {
+  grid-column: 2 / 3;
+}
+
+@media (max-width: 768px) {
+  .features-grid-5 {
+    grid-template-columns: 1fr;
+  }
+
+  .features-grid-5 > li:nth-child(4),
+  .features-grid-5 > li:nth-child(5) {
+    grid-column: auto;
+  }
+}
+
 .marketing-page-features .features-pillars {
   display: flex;
   flex-direction: column;

--- a/src/marketing/FeaturesPage.tsx
+++ b/src/marketing/FeaturesPage.tsx
@@ -1,5 +1,34 @@
+import { Sparkles, Users, FileText, Brain, Download } from 'lucide-react'
 import { MarketingLayout } from './MarketingLayout'
 import { goToLogin } from './utils'
+
+const CORE_FEATURES = [
+  {
+    icon: Sparkles,
+    title: 'AI Writing Assistant',
+    body: 'Four specialist agents — engineering, product, legal, design — read your draft and push back where it matters. Not a spell-checker. A standing review panel that disagrees on purpose.',
+  },
+  {
+    icon: Users,
+    title: 'Real-time Collaboration',
+    body: 'Watch agent cursors move through your document as they think, edit, and comment alongside you. Every suggestion lands directly in the draft — not a separate thread or side panel.',
+  },
+  {
+    icon: FileText,
+    title: 'Google Docs Integration',
+    body: 'Import from and export to Google Docs without format gymnastics. Your document stays yours — move it in, work with agents, move it back out.',
+  },
+  {
+    icon: Brain,
+    title: 'Agent Memory',
+    body: 'Agents carry context across a session. They remember what you decided three sections ago, track open questions they raised, and notice when you contradict an earlier choice.',
+  },
+  {
+    icon: Download,
+    title: 'Markdown Export',
+    body: 'Copy your finished draft as Markdown, HTML, or plain text in one click. No lock-in. No proprietary format. Your writing leaves in a format every tool understands.',
+  },
+]
 
 const PILLARS = [
   {
@@ -66,6 +95,29 @@ export function FeaturesPage() {
           inside it, edit alongside you, and disagree on purpose.
         </p>
       </header>
+
+      <section className="features-core-grid" aria-labelledby="features-core-title">
+        <header className="marketing-section-header">
+          <p className="marketing-eyebrow">What's inside</p>
+          <h2 id="features-core-title" className="marketing-section-title">
+            Five things that make it different
+          </h2>
+        </header>
+        <ul className="features-grid-5">
+          {CORE_FEATURES.map(f => {
+            const Icon = f.icon
+            return (
+              <li key={f.title} className="marketing-features-card">
+                <span className="marketing-features-icon" aria-hidden="true">
+                  <Icon size={22} strokeWidth={1.5} />
+                </span>
+                <h3 className="marketing-features-title">{f.title}</h3>
+                <p className="marketing-features-body">{f.body}</p>
+              </li>
+            )
+          })}
+        </ul>
+      </section>
 
       <section className="features-pillars" aria-label="Core pillars">
         {PILLARS.map(p => (


### PR DESCRIPTION
Refinery merge for mk-wisp-1d2 (worker: furiosa, source: mk-ee8). Expands /features page with detailed sections. Rebased by refinery.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
