### PR TITLE
feat(marketing): add /examples page (mk-553)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8547,6 +8547,128 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
 }
 
 /* ============================================================
+   Examples page
+   ============================================================ */
+
+.marketing-page-examples .examples-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin: 48px 0 96px;
+}
+
+.examples-card {
+  position: relative;
+  padding: 28px 24px;
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: border-color var(--duration-fast) ease, transform var(--duration-fast) ease;
+}
+
+.examples-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--example-accent);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  opacity: 0.85;
+}
+
+.examples-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--border-default);
+}
+
+.examples-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.examples-card-doc-type {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-tertiary);
+  font-weight: 600;
+}
+
+.examples-card-agent-tag {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 100px;
+  border: 1px solid currentColor;
+  opacity: 0.85;
+}
+
+.examples-card-headline {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.examples-card-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.examples-card-demo-label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-tertiary);
+  margin-bottom: 5px;
+  font-weight: 600;
+}
+
+.examples-card-draft,
+.examples-card-comment {
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+}
+
+.examples-card-draft {
+  background: var(--surface-0);
+  border: 1px solid var(--border-subtle);
+}
+
+.examples-card-draft-text {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+.examples-card-comment {
+  background: color-mix(in srgb, var(--example-accent) 6%, var(--surface-0));
+  border: 1px solid color-mix(in srgb, var(--example-accent) 20%, transparent);
+}
+
+.examples-card-comment-text {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+/* ============================================================
    Responsive rules for new pages
    ============================================================ */
 
@@ -8586,6 +8708,8 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
   .marketing-page-agents .agents-grid { grid-template-columns: 1fr; }
   .agents-how-step { grid-template-columns: 40px 1fr; gap: 16px; padding: 20px 0; }
   .agents-model-card { padding: 20px; }
+
+  .marketing-page-examples .examples-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
 @media (max-width: 480px) {
@@ -8597,6 +8721,8 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
     grid-template-columns: 1.6fr 0.8fr 0.8fr 0.8fr;
   }
   .pricing-compare-cell { padding: 10px 8px; }
+
+  .marketing-page-examples .examples-grid { grid-template-columns: 1fr; }
 }
 
 /* ── Changelog page ───────────────────────────── */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ const PricingPage = lazy(() => import('./marketing/PricingPage').then(m => ({ de
 const AboutPage = lazy(() => import('./marketing/AboutPage').then(m => ({ default: m.AboutPage })))
 const UseCasesPage = lazy(() => import('./marketing/UseCasesPage').then(m => ({ default: m.UseCasesPage })))
 const AgentsPage = lazy(() => import('./marketing/AgentsPage').then(m => ({ default: m.AgentsPage })))
+const ExamplesPage = lazy(() => import('./marketing/ExamplesPage').then(m => ({ default: m.ExamplesPage })))
 const LegalPage = lazy(() => import('./LegalPage').then(m => ({ default: m.LegalPage })))
 const ReferralsPage = lazy(() => import('./ReferralsPage').then(m => ({ default: m.ReferralsPage })))
 const ChangelogPage = lazy(() => import('./ChangelogPage').then(m => ({ default: m.ChangelogPage })))
@@ -495,6 +496,7 @@ function App() {
   if (window.location.pathname === '/about') return <Suspense><AboutPage /></Suspense>
   if (window.location.pathname === '/use-cases') return <Suspense><UseCasesPage /></Suspense>
   if (window.location.pathname === '/agents') return <Suspense><AgentsPage /></Suspense>
+  if (window.location.pathname === '/examples') return <Suspense><ExamplesPage /></Suspense>
 
   // Referrals page -- requires a signed-in user (or localhost).
   // Uses full-page nav on close to match the legal-pages pattern so the

--- a/src/marketing/ExamplesPage.tsx
+++ b/src/marketing/ExamplesPage.tsx
@@ -1,0 +1,130 @@
+import { MarketingLayout } from './MarketingLayout'
+import { goToLogin } from './utils'
+
+type Example = {
+  slug: string
+  label: string
+  docType: string
+  agent: string
+  agentColor: string
+  headline: string
+  draft: string
+  comment: string
+}
+
+const EXAMPLES: Example[] = [
+  {
+    slug: 'prd',
+    label: 'Product requirements',
+    docType: 'PRD',
+    agent: 'Nova',
+    agentColor: '#ff6961',
+    headline: 'A PRD that survives the first meeting',
+    draft: 'We will build a notification system to improve user engagement by sending timely alerts.',
+    comment:
+      '"Improve user engagement" is not a goal. What is the current engagement rate? What does the needle moving look like? Who is receiving these notifications, on which surface, and what action do you want them to take?',
+  },
+  {
+    slug: 'rfc',
+    label: 'Technical RFC',
+    docType: 'RFC',
+    agent: 'Aiden',
+    agentColor: '#30d158',
+    headline: 'A spec that names the tradeoffs',
+    draft:
+      'The service will use an in-memory cache to speed up repeated queries. Cache entries will be invalidated when the underlying data changes.',
+    comment:
+      '"When the underlying data changes" is not an invalidation strategy — it is a wish. How does the cache know data changed? What is the TTL fallback? What happens under partial failure?',
+  },
+  {
+    slug: 'contract',
+    label: 'Contract clause',
+    docType: 'Legal',
+    agent: 'Lex',
+    agentColor: '#64d2ff',
+    headline: 'Terms that mean what they say',
+    draft:
+      'The Company will use commercially reasonable efforts to maintain service uptime and respond to support requests in a timely manner.',
+    comment:
+      '"Commercially reasonable" and "timely" are undefined. What is the SLA? What is the support response window? What is the remedy if these are not met? Every undefined term is a future negotiation.',
+  },
+  {
+    slug: 'onboarding',
+    label: 'Onboarding flow',
+    docType: 'UX brief',
+    agent: 'Mira',
+    agentColor: '#ffd60a',
+    headline: 'A flow the first user can actually finish',
+    draft:
+      'The onboarding flow will guide new users through account setup, profile completion, and feature discovery in three steps.',
+    comment:
+      'What is the empty state for each step? What happens if the user skips profile completion? Three steps feels right on desktop — what does step two look like on a 375px screen at 8am?',
+  },
+]
+
+export function ExamplesPage() {
+  return (
+    <MarketingLayout pageClass="marketing-page-examples" shader="mono" activePath="/examples">
+      <header className="marketing-page-header">
+        <p className="marketing-eyebrow">Examples</p>
+        <h1 className="marketing-page-title">
+          What it looks like{' '}
+          <span className="marketing-page-title-italic">in practice.</span>
+        </h1>
+        <p className="marketing-page-lede">
+          Four document types, four specialists. Each example shows a real draft and the
+          question an agent asks before it moves on.
+        </p>
+      </header>
+
+      <div className="examples-grid">
+        {EXAMPLES.map(ex => (
+          <article
+            key={ex.slug}
+            className="examples-card"
+            style={{ ['--example-accent' as string]: ex.agentColor }}
+          >
+            <header className="examples-card-head">
+              <span className="examples-card-doc-type">{ex.docType}</span>
+              <span
+                className="examples-card-agent-tag"
+                style={{ color: ex.agentColor, borderColor: ex.agentColor }}
+              >
+                {ex.agent}
+              </span>
+            </header>
+            <h2 className="examples-card-headline">{ex.headline}</h2>
+            <div className="examples-card-demo">
+              <div className="examples-card-draft">
+                <span className="examples-card-demo-label">Draft</span>
+                <p className="examples-card-draft-text">{ex.draft}</p>
+              </div>
+              <div className="examples-card-comment">
+                <span className="examples-card-demo-label">
+                  {ex.agent} in the margin
+                </span>
+                <p className="examples-card-comment-text">{ex.comment}</p>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <section className="marketing-closing">
+        <h2 className="marketing-closing-title">
+          Paste a draft. See what it&apos;s missing.
+        </h2>
+        <p className="marketing-closing-sub">
+          Free while in early access. No credit card required.
+        </p>
+        <button
+          type="button"
+          className="marketing-cta-primary marketing-closing-cta"
+          onClick={() => goToLogin('signup')}
+        >
+          Try Markup free
+        </button>
+      </section>
+    </MarketingLayout>
+  )
+}

--- a/src/marketing/MarketingLayout.tsx
+++ b/src/marketing/MarketingLayout.tsx
@@ -21,6 +21,7 @@ type NavLink = { href: string; label: string }
 const DEFAULT_NAV: NavLink[] = [
   { href: '/features', label: 'Features' },
   { href: '/use-cases', label: 'Use cases' },
+  { href: '/examples', label: 'Examples' },
   { href: '/agents', label: 'Agents' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/about', label: 'About' },
@@ -127,6 +128,7 @@ export function MarketingLayout({
               <span className="marketing-footer-heading">Product</span>
               <a href="/features" className="marketing-footer-link">Features</a>
               <a href="/use-cases" className="marketing-footer-link">Use cases</a>
+              <a href="/examples" className="marketing-footer-link">Examples</a>
               <a href="/agents" className="marketing-footer-link">Agents</a>
               <a href="/pricing" className="marketing-footer-link">Pricing</a>
             </div>


### PR DESCRIPTION
Refinery merge for mk-wisp-61v (worker: capable, source: mk-553). New /examples marketing page.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
