### PR TITLE
feat(ollama): add Ollama provider for local model support (mk-xvi)

### DIFF
--- a/api/ollama.ts
+++ b/api/ollama.ts
@@ -1,0 +1,128 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { z } from 'zod'
+
+const MAX_PROMPT_LENGTH = 200_000
+
+const requestBodySchema = z.object({
+  prompt: z.string().min(1).max(MAX_PROMPT_LENGTH),
+})
+
+export const maxDuration = 120
+
+// Extract JSON from response text, handling markdown code fences
+function extractJSON(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim()
+  try { return JSON.parse(trimmed) } catch { /* continue */ }
+
+  const fenceMatch = trimmed.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/)
+  if (fenceMatch) {
+    try { return JSON.parse(fenceMatch[1].trim()) } catch { /* continue */ }
+  }
+
+  const braceStart = trimmed.indexOf('{')
+  const braceEnd = trimmed.lastIndexOf('}')
+  if (braceStart !== -1 && braceEnd > braceStart) {
+    try { return JSON.parse(trimmed.slice(braceStart, braceEnd + 1)) } catch { /* continue */ }
+  }
+
+  return null
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  // Base URL: client header > env var > default localhost (dev only)
+  const ollamaUrl = (req.headers['x-ollama-url'] as string)
+    || process.env.OLLAMA_BASE_URL
+    || 'http://localhost:11434'
+
+  const model = (req.headers['x-ollama-model'] as string)
+    || process.env.OLLAMA_MODEL
+    || 'llama3.2'
+
+  const parsed = requestBodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    return res.status(400).json({ error: `Invalid request: ${issue.path.join('.') || '(body)'}: ${issue.message}` })
+  }
+
+  const { prompt } = parsed.data
+  const agentName = req.headers['x-agent-name'] as string | undefined
+
+  const jsonPrompt = `${prompt}
+
+RESPONSE FORMAT: Return ONLY a single JSON object (no markdown, no explanation). The JSON must include:
+- "type": one of "insert", "replace", "read", "chat", "search", "rename", "delete", "propose", "plan", "ask", "image"
+- "thought": max 4 words summarizing your action
+- "reasoning": array of 2-3 short strings
+- For "insert": "position" (REQUIRED — use "after:S1", "after:S2" etc. matching section refs, or "end"), "content" (THE ACTUAL TEXT TO ADD), "chatBefore" (brief note)
+- For "replace": "searchText", "replaceWith", "chatBefore"
+- For "chat": "chatMessage"
+- For "search": "query", "shouldContinue": true
+- "shouldContinue": boolean (usually false)
+
+CRITICAL: For "insert", the "content" field MUST contain the full document text you want to add.`
+
+  try {
+    const ollamaRes = await fetch(`${ollamaUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: jsonPrompt }],
+        temperature: 0.7,
+        stream: false,
+      }),
+    })
+
+    if (!ollamaRes.ok) {
+      const errText = await ollamaRes.text().catch(() => '')
+      console.error('[ollama-proxy] upstream error:', ollamaRes.status, errText.slice(0, 200))
+      return res.status(ollamaRes.status).json({
+        error: `Ollama error ${ollamaRes.status}`,
+        detail: errText.slice(0, 200),
+      })
+    }
+
+    const ollamaData = await ollamaRes.json() as {
+      choices?: Array<{ message?: { content?: string } }>
+      usage?: { prompt_tokens?: number, completion_tokens?: number }
+    }
+
+    const rawText = ollamaData.choices?.[0]?.message?.content ?? ''
+    if (!rawText) {
+      return res.status(500).json({ error: 'Empty response from Ollama' })
+    }
+
+    const action = extractJSON(rawText)
+    if (!action || !action.type) {
+      console.error('[ollama-proxy] failed to parse JSON:', rawText.slice(0, 500))
+      return res.status(500).json({ error: 'Failed to parse action JSON from model response' })
+    }
+
+    // Recovery: cross-copy between content and afterText
+    if (action.type === 'insert' && !action.content && action.afterText) {
+      action.content = action.afterText
+    }
+
+    console.log('[ollama-proxy]', agentName, action.type, { model })
+
+    return res.status(200).json({
+      action,
+      usage: {
+        input: ollamaData.usage?.prompt_tokens ?? 0,
+        output: ollamaData.usage?.completion_tokens ?? 0,
+      },
+    })
+  } catch (err) {
+    console.error('[ollama-proxy] request failed:', err)
+    const errMsg = err instanceof Error ? err.message : String(err)
+    return res.status(500).json({
+      error: 'Proxy request failed',
+      code: 'PROXY_ERROR',
+      detail: errMsg,
+    })
+  }
+}

--- a/src/ExperimentControls.tsx
+++ b/src/ExperimentControls.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 import type { ExperimentSettings } from './types'
 import { DEFAULT_EXPERIMENTS } from './types'
 import { AGENT_PRESETS } from './lib/agent-presets'
+import { getOllamaSettings, saveOllamaSettings, DEFAULT_OLLAMA_URL, DEFAULT_OLLAMA_MODEL } from './lib/ollama-settings'
+import { resetRateLimiter } from './agent'
 
 interface Props {
   settings: ExperimentSettings
@@ -17,6 +19,11 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
   const [keyVisible, setKeyVisible] = useState(false)
   const [keySaving, setKeySaving] = useState(false)
   const [keySaved, setKeySaved] = useState(false)
+
+  const storedOllama = getOllamaSettings()
+  const [ollamaUrl, setOllamaUrl] = useState(storedOllama.url || '')
+  const [ollamaModel, setOllamaModel] = useState(storedOllama.model || '')
+  const [ollamaSaved, setOllamaSaved] = useState(false)
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
@@ -42,6 +49,16 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
   const resetAll = () => {
     setLocal({ ...DEFAULT_EXPERIMENTS })
     onChange({ ...DEFAULT_EXPERIMENTS })
+  }
+
+  const saveOllama = () => {
+    saveOllamaSettings({
+      url: ollamaUrl.trim() || DEFAULT_OLLAMA_URL,
+      model: ollamaModel.trim() || DEFAULT_OLLAMA_MODEL,
+    })
+    resetRateLimiter()
+    setOllamaSaved(true)
+    setTimeout(() => setOllamaSaved(false), 2000)
   }
 
   return (
@@ -111,6 +128,48 @@ export function ExperimentControls({ settings, onChange, onClose, apiKey, onSave
               </div>
             </div>
           )}
+
+          <div className="exp-section">
+            <div className="exp-section-label">Ollama (local models)</div>
+            <div className="exp-field">
+              <div className="exp-field-header">
+                <span className="exp-label">Base URL</span>
+              </div>
+              <input
+                type="text"
+                value={ollamaUrl}
+                onChange={e => { setOllamaUrl(e.target.value); setOllamaSaved(false) }}
+                placeholder={DEFAULT_OLLAMA_URL}
+                className="exp-key-input"
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+            <div className="exp-field">
+              <div className="exp-field-header">
+                <span className="exp-label">Model</span>
+              </div>
+              <div className="exp-key-row">
+                <input
+                  type="text"
+                  value={ollamaModel}
+                  onChange={e => { setOllamaModel(e.target.value); setOllamaSaved(false) }}
+                  placeholder={DEFAULT_OLLAMA_MODEL}
+                  className="exp-key-input"
+                  spellCheck={false}
+                  autoComplete="off"
+                />
+                <button type="button" className="exp-key-save" disabled={ollamaSaved} onClick={saveOllama}>
+                  {ollamaSaved ? 'Saved' : 'Save'}
+                </button>
+              </div>
+              <div className="exp-key-footer">
+                <span className="exp-key-hint">
+                  When set, agents use Ollama instead of Gemini. Leave blank to use Gemini.
+                </span>
+              </div>
+            </div>
+          </div>
 
           <div className="exp-section">
             <div className="exp-section-label">Default agents</div>

--- a/src/__tests__/ollama-provider.test.ts
+++ b/src/__tests__/ollama-provider.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../lib/api-key-cache', () => ({
+  getStoredApiKey: vi.fn(() => null),
+}))
+
+vi.stubGlobal('window', {
+  location: { pathname: '/s/ollama-test-session' },
+})
+
+import { createOllamaProvider } from '../agent/providers/ollama-provider'
+import type { AgentProvider, AgentResponse } from '../agent/provider'
+import { AgentError, type AskParams } from '../agent'
+
+function makeParams(overrides?: Partial<AskParams>): AskParams {
+  return {
+    agentName: 'Aiden',
+    ownerName: 'Oliver',
+    docText: 'Test document',
+    chatHistory: [],
+    trigger: 'instruction',
+    instruction: 'add detail',
+    persona: 'Test persona',
+    otherAgents: ['Nova'],
+    ...overrides,
+  }
+}
+
+describe('AgentProvider contract — ollama adapter', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+  let provider: AgentProvider
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    provider = createOllamaProvider({ ollamaUrl: 'http://localhost:11434', model: 'llama3.2' })
+  })
+
+  afterEach(() => {
+    provider.dispose()
+    vi.restoreAllMocks()
+  })
+
+  describe('shape', () => {
+    it('createOllamaProvider returns generate and dispose', () => {
+      expect(typeof provider.generate).toBe('function')
+      expect(typeof provider.dispose).toBe('function')
+    })
+
+    it('generate resolves to { action, usage? }', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          action: { type: 'chat', chatMessage: 'hello' },
+          usage: { input: 8, output: 4 },
+        }),
+      })
+
+      const result: AgentResponse = await provider.generate(makeParams())
+      expect(result.action.type).toBe('chat')
+      expect(result.usage).toEqual({ input: 8, output: 4 })
+    })
+
+    it('dispose is idempotent', () => {
+      expect(provider.dispose()).toBeUndefined()
+      expect(provider.dispose()).toBeUndefined()
+    })
+  })
+
+  describe('transport behavior', () => {
+    it('POSTs to /api/ollama with a prompt string body', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ action: { type: 'chat', chatMessage: 'ok' } }),
+      })
+
+      await provider.generate(makeParams())
+
+      const [url, init] = fetchSpy.mock.calls[0]
+      expect(url).toBe('/api/ollama')
+      expect(init.method).toBe('POST')
+      const body = JSON.parse(init.body)
+      expect(body).toHaveProperty('prompt')
+      expect(typeof body.prompt).toBe('string')
+    })
+
+    it('attaches X-Ollama-Url, X-Ollama-Model, X-Session-Id headers', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ action: { type: 'chat', chatMessage: 'ok' } }),
+      })
+
+      await provider.generate(makeParams({ agentName: 'Nova' }))
+
+      const headers = fetchSpy.mock.calls[0][1].headers
+      expect(headers['X-Ollama-Url']).toBe('http://localhost:11434')
+      expect(headers['X-Ollama-Model']).toBe('llama3.2')
+      expect(headers['X-Session-Id']).toBe('ollama-test-session')
+      expect(headers['X-Agent-Name']).toBe('Nova')
+    })
+
+    it('honors custom apiUrl option', async () => {
+      const custom = createOllamaProvider({ apiUrl: '/api/custom-ollama' })
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ action: { type: 'chat', chatMessage: 'ok' } }),
+      })
+
+      await custom.generate(makeParams())
+      expect(fetchSpy.mock.calls[0][0]).toBe('/api/custom-ollama')
+      custom.dispose()
+    })
+
+    it('omits provider headers when not configured', async () => {
+      const bare = createOllamaProvider()
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ action: { type: 'chat', chatMessage: 'ok' } }),
+      })
+
+      await bare.generate(makeParams())
+      const headers = fetchSpy.mock.calls[0][1].headers
+      expect(headers['X-Ollama-Url']).toBeUndefined()
+      expect(headers['X-Ollama-Model']).toBeUndefined()
+      bare.dispose()
+    })
+  })
+
+  describe('error mapping', () => {
+    it('throws AgentError with rate_limit code on 429', async () => {
+      fetchSpy.mockResolvedValueOnce({ ok: false, status: 429, json: async () => ({}) })
+
+      await expect(provider.generate(makeParams())).rejects.toMatchObject({
+        name: 'AgentError',
+        code: 'rate_limit',
+        status: 429,
+        retryable: true,
+      })
+    })
+
+    it('throws AgentError with api_error on non-2xx/429', async () => {
+      fetchSpy.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({ error: 'service unavailable' }) })
+
+      const err = await provider.generate(makeParams()).catch(e => e)
+      expect(err).toBeInstanceOf(AgentError)
+      expect((err as AgentError).code).toBe('api_error')
+      expect((err as AgentError).status).toBe(503)
+    })
+
+    it('throws AgentError with parse_error on missing action', async () => {
+      fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ action: null }) })
+
+      const err = await provider.generate(makeParams()).catch(e => e)
+      expect(err).toBeInstanceOf(AgentError)
+      expect((err as AgentError).code).toBe('parse_error')
+    })
+
+    it('throws AgentError with network_error on fetch failure', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      const err = await provider.generate(makeParams()).catch(e => e)
+      expect(err).toBeInstanceOf(AgentError)
+      expect((err as AgentError).code).toBe('network_error')
+      expect((err as AgentError).retryable).toBe(true)
+    })
+  })
+
+  describe('seam isolation', () => {
+    it('does not apply rate limiting — caller owns that', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ action: { type: 'chat', chatMessage: 'ok' } }),
+      })
+
+      const start = Date.now()
+      await provider.generate(makeParams())
+      await provider.generate(makeParams())
+      const elapsed = Date.now() - start
+
+      expect(elapsed).toBeLessThan(1000)
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,8 +19,10 @@ export class AgentError extends Error {
 
 import type { AgentProvider } from './agent/provider'
 import { createGeminiProvider } from './agent/providers/gemini-provider'
+import { createOllamaProvider } from './agent/providers/ollama-provider'
 import { createRateLimiter } from './agent/rate-limiter'
 import { DEFAULT_PERSONAS as DEFAULT_PERSONAS_INTERNAL } from './lib/prompts'
+import { getOllamaSettings, isOllamaConfigured } from './lib/ollama-settings'
 
 // Client-side rate limiter: enforces minimum spacing between calls to stay within free tier limits.
 // The server handles retries for transient errors via AI SDK's maxRetries.
@@ -321,12 +323,21 @@ export function validateAction(action: AgentAction): boolean {
   }
 }
 
-// Module-level provider singleton. Lazy-init so tests and non-Gemini wiring
-// (Wave 2/3 Claude + OpenAI adapters) can swap via setAgentProvider before
-// the first call. Resets on resetRateLimiter() for test isolation.
+// Module-level provider singleton. Lazy-init on first call.
+// Resets on resetRateLimiter() for test isolation and on provider change.
 let provider: AgentProvider | null = null
+
+export function setAgentProvider(p: AgentProvider): void {
+  provider?.dispose()
+  provider = p
+}
+
 function getProvider(): AgentProvider {
-  if (!provider) provider = createGeminiProvider()
+  if (!provider) {
+    provider = isOllamaConfigured()
+      ? createOllamaProvider(getOllamaSettings())
+      : createGeminiProvider()
+  }
   return provider
 }
 

--- a/src/agent/providers/ollama-provider.ts
+++ b/src/agent/providers/ollama-provider.ts
@@ -1,0 +1,83 @@
+// Ollama provider — adapter that calls the /api/ollama proxy.
+//
+// Ollama exposes an OpenAI-compatible /v1/chat/completions endpoint.
+// The proxy keeps the Ollama base URL server-configurable while allowing
+// client-side override via X-Ollama-Url + X-Ollama-Model headers (BYOU/BYOM).
+// Behavior mirrors gemini-provider: same error mapping, no rate limiting.
+
+import { AgentError } from '../../agent'
+import type { AskParams } from '../../agent'
+import type { AgentProvider, AgentResponse } from '../provider'
+import { buildPrompt } from '../../agent'
+
+const DEFAULT_API_URL = '/api/ollama'
+
+export interface OllamaProviderOptions {
+  apiUrl?: string
+  ollamaUrl?: string
+  model?: string
+}
+
+export function createOllamaProvider(options: OllamaProviderOptions = {}): AgentProvider {
+  const apiUrl = options.apiUrl ?? DEFAULT_API_URL
+
+  async function generate(params: AskParams): Promise<AgentResponse> {
+    const prompt = buildPrompt(params)
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (options.ollamaUrl) headers['X-Ollama-Url'] = options.ollamaUrl
+    if (options.model) headers['X-Ollama-Model'] = options.model
+
+    const sessionMatch = typeof window !== 'undefined'
+      ? window.location.pathname.match(/\/s\/([^/]+)/)
+      : null
+    if (sessionMatch) headers['X-Session-Id'] = sessionMatch[1]
+    if (params.agentName) headers['X-Agent-Name'] = params.agentName
+
+    let res: Response
+    try {
+      res = await fetch(apiUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ prompt }),
+      })
+    } catch (err) {
+      throw new AgentError(
+        `Network error: ${err instanceof Error ? err.message : String(err)}`,
+        'network_error',
+        undefined,
+        true,
+      )
+    }
+
+    if (res.status === 429) {
+      throw new AgentError('Rate limit exceeded', 'rate_limit', 429, true)
+    }
+
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({} as { error?: string }))
+      throw new AgentError(
+        errBody.error || `API error ${res.status}`,
+        'api_error',
+        res.status,
+      )
+    }
+
+    const data = await res.json().catch(() => null) as {
+      action?: unknown
+      usage?: { input: number, output: number }
+    } | null
+
+    if (!data || !data.action || typeof data.action !== 'object') {
+      throw new AgentError('Empty action from API', 'parse_error')
+    }
+
+    return {
+      action: data.action as AgentResponse['action'],
+      usage: data.usage,
+    }
+  }
+
+  function dispose(): void {}
+
+  return { generate, dispose }
+}

--- a/src/lib/ollama-settings.ts
+++ b/src/lib/ollama-settings.ts
@@ -1,0 +1,47 @@
+const OLLAMA_URL_KEY = 'collab-ollama-url'
+const OLLAMA_MODEL_KEY = 'collab-ollama-model'
+
+export const DEFAULT_OLLAMA_URL = 'http://localhost:11434'
+export const DEFAULT_OLLAMA_MODEL = 'llama3.2'
+
+export interface OllamaSettings {
+  url: string
+  model: string
+}
+
+function getItem(key: string, fallback: string): string {
+  try {
+    return localStorage.getItem(key) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function setItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch {
+    // ignore — e.g. private mode
+  }
+}
+
+export function getOllamaSettings(): OllamaSettings {
+  return {
+    url: getItem(OLLAMA_URL_KEY, DEFAULT_OLLAMA_URL),
+    model: getItem(OLLAMA_MODEL_KEY, DEFAULT_OLLAMA_MODEL),
+  }
+}
+
+export function saveOllamaSettings(settings: Partial<OllamaSettings>): void {
+  if (settings.url !== undefined) setItem(OLLAMA_URL_KEY, settings.url)
+  if (settings.model !== undefined) setItem(OLLAMA_MODEL_KEY, settings.model)
+}
+
+export function isOllamaConfigured(): boolean {
+  try {
+    const url = localStorage.getItem(OLLAMA_URL_KEY)
+    return url !== null && url.trim().length > 0
+  } catch {
+    return false
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,95 @@ export default defineConfig(({ mode }) => {
             res.end(JSON.stringify({ ok: true, skipped: true, reason: 'dev mode' }))
           })
 
+          server.middlewares.use('/api/ollama', async (req, res) => {
+            if (req.method !== 'POST') {
+              res.writeHead(405, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: 'Method not allowed' }))
+              return
+            }
+
+            const ollamaUrl = (req.headers['x-ollama-url'] as string)
+              || env.OLLAMA_BASE_URL
+              || 'http://localhost:11434'
+            const model = (req.headers['x-ollama-model'] as string)
+              || env.OLLAMA_MODEL
+              || 'llama3.2'
+
+            const chunks: Buffer[] = []
+            for await (const chunk of req) chunks.push(chunk as Buffer)
+            let prompt: string
+            try {
+              const body = JSON.parse(Buffer.concat(chunks).toString())
+              prompt = body.prompt
+            } catch {
+              res.writeHead(400, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: 'Invalid JSON body' }))
+              return
+            }
+
+            const jsonPrompt = `${prompt}\n\nRESPONSE FORMAT: Return ONLY a single JSON object (no markdown, no explanation). Include "type", "thought" (max 4 words), "reasoning" (2-3 strings), and action-specific fields. For "insert": "position" and "content". For "replace": "searchText" and "replaceWith". For "chat": "chatMessage". Set "shouldContinue": false unless searching.`
+
+            try {
+              const ollamaRes = await fetch(`${ollamaUrl}/v1/chat/completions`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  model,
+                  messages: [{ role: 'user', content: jsonPrompt }],
+                  temperature: 0.7,
+                  stream: false,
+                }),
+              })
+
+              if (!ollamaRes.ok) {
+                const errText = await ollamaRes.text().catch(() => '')
+                res.writeHead(ollamaRes.status, { 'Content-Type': 'application/json' })
+                res.end(JSON.stringify({ error: `Ollama error ${ollamaRes.status}`, detail: errText.slice(0, 200) }))
+                return
+              }
+
+              const ollamaData = await ollamaRes.json() as {
+                choices?: Array<{ message?: { content?: string } }>
+                usage?: { prompt_tokens?: number, completion_tokens?: number }
+              }
+
+              const rawText = ollamaData.choices?.[0]?.message?.content ?? ''
+              const trimmed = rawText.trim()
+              let action: Record<string, unknown> | null = null
+              try { action = JSON.parse(trimmed) } catch { /* continue */ }
+              if (!action) {
+                const m = trimmed.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/)
+                if (m) try { action = JSON.parse(m[1].trim()) } catch { /* continue */ }
+              }
+              if (!action) {
+                const s = trimmed.indexOf('{'), e = trimmed.lastIndexOf('}')
+                if (s !== -1 && e > s) try { action = JSON.parse(trimmed.slice(s, e + 1)) } catch { /* continue */ }
+              }
+
+              if (!action || !action.type) {
+                res.writeHead(500, { 'Content-Type': 'application/json' })
+                res.end(JSON.stringify({ error: 'Failed to parse action JSON from model response' }))
+                return
+              }
+
+              if (action.type === 'insert' && !action.content && action.afterText) {
+                action.content = action.afterText
+              }
+
+              res.writeHead(200, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({
+                action,
+                usage: {
+                  input: ollamaData.usage?.prompt_tokens ?? 0,
+                  output: ollamaData.usage?.completion_tokens ?? 0,
+                },
+              }))
+            } catch (err) {
+              res.writeHead(500, { 'Content-Type': 'application/json' })
+              res.end(JSON.stringify({ error: 'Proxy request failed', detail: String(err) }))
+            }
+          })
+
           server.middlewares.use('/api/gemini', async (req, res, next) => {
             if (req.method !== 'POST') { next(); return }
 


### PR DESCRIPTION
Refinery merge for mk-wisp-79y (worker: dementus, source: mk-xvi). Adds Ollama provider, /api/ollama endpoint, provider tests, vite proxy config, ExperimentControls wiring. Rebased by refinery (original branch was stale and would have reverted marketing work).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
