### PR TITLE
fix(marketing): migrate LegalPage to MarketingLayout (mk-rz9)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8716,3 +8716,70 @@ a.sidebar-avatar-menu-item { text-decoration: none; }
   .pricing-tier:hover,
   .agents-card:hover { transform: none; }
 }
+
+/* Legal + Changelog pages inside MarketingLayout */
+.marketing-page-legal-inner,
+.marketing-page-changelog-inner {
+  padding-bottom: 96px;
+}
+
+.marketing-page-legal-inner .legal-content,
+.marketing-page-changelog-inner .changelog-content {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.marketing-page-changelog-inner .changelog-content h1 {
+  font-family: var(--font-serif);
+  font-size: 28px;
+  font-weight: 300;
+  color: var(--text-primary);
+  margin: 40px 0 6px;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.marketing-page-changelog-inner .changelog-content h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 28px 0 8px;
+  letter-spacing: -0.01em;
+}
+
+.marketing-page-changelog-inner .changelog-content h3 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 20px 0 6px;
+}
+
+.marketing-page-changelog-inner .changelog-content p {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  margin: 0 0 12px;
+}
+
+.marketing-page-changelog-inner .changelog-content ul,
+.marketing-page-changelog-inner .changelog-content ol {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  margin: 0 0 12px;
+  padding-left: 20px;
+}
+
+.marketing-page-changelog-inner .changelog-content li { margin-bottom: 4px; }
+
+.marketing-page-changelog-inner .changelog-content a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--border-default);
+  transition: text-decoration-color var(--duration-fast) ease;
+}
+
+.marketing-page-changelog-inner .changelog-content a:hover {
+  text-decoration-color: var(--accent);
+}

--- a/src/LegalPage.tsx
+++ b/src/LegalPage.tsx
@@ -1,47 +1,31 @@
-import { BlobAvatar } from './blob-avatar'
+import { MarketingLayout } from './marketing/MarketingLayout'
 
 interface Props {
   page: 'privacy' | 'terms'
 }
 
 export function LegalPage({ page }: Props) {
-  return (
-    <div className="home">
-      <div className="home-inner">
-        <nav className="home-nav">
-          <div className="home-nav-logo">
-            <a href="/" className="home-nav-logo-link">
-              <div className="home-nav-blob-wrap">
-                <BlobAvatar name="Collab" size={24} state="logo" color="#30d158" />
-              </div>
-              <span className="home-nav-wordmark">Collab</span>
-            </a>
-          </div>
-        </nav>
+  const title = page === 'privacy' ? 'Privacy Policy' : 'Terms of Service'
+  const activePath = page === 'privacy' ? '/privacy' : '/terms'
 
+  return (
+    <MarketingLayout pageClass="marketing-page-legal" shader="none" activePath={activePath}>
+      <div className="marketing-page-legal-inner">
+        <header className="marketing-page-header">
+          <p className="marketing-eyebrow">Legal</p>
+          <h1 className="marketing-page-title">{title}</h1>
+        </header>
         <section className="legal-content">
           {page === 'privacy' ? <PrivacyContent /> : <TermsContent />}
         </section>
-
-        <footer className="home-footer">
-          <div className="home-footer-left">
-            <span className="home-footer-brand">Collab</span>
-          </div>
-          <div className="home-footer-right">
-            <a href="/privacy" className="home-footer-link">Privacy</a>
-            <a href="/terms" className="home-footer-link">Terms</a>
-            <span className="home-footer-copy">Built by n3wth</span>
-          </div>
-        </footer>
       </div>
-    </div>
+    </MarketingLayout>
   )
 }
 
 function PrivacyContent() {
   return (
     <>
-      <h1 className="legal-title">Privacy Policy</h1>
       <p className="legal-date">Last updated: March 19, 2026</p>
 
       <h2>What we collect</h2>
@@ -54,15 +38,15 @@ function PrivacyContent() {
         <li>Display your identity to collaborators</li>
       </ul>
 
-      <h2>What we don't do</h2>
+      <h2>What we don&apos;t do</h2>
       <ul>
-        <li>We don't sell your data</li>
-        <li>We don't serve ads</li>
-        <li>We don't share your data with third parties beyond our infrastructure providers (Supabase, Vercel, Google Gemini API)</li>
+        <li>We don&apos;t sell your data</li>
+        <li>We don&apos;t serve ads</li>
+        <li>We don&apos;t share your data with third parties beyond our infrastructure providers (Supabase, Vercel, Google Gemini API)</li>
       </ul>
 
       <h2>Data storage</h2>
-      <p>Documents and messages are stored in Supabase (hosted on AWS). API keys you provide in Settings are stored in your browser's localStorage only and never sent to our servers.</p>
+      <p>Documents and messages are stored in Supabase (hosted on AWS). API keys you provide in Settings are stored in your browser&apos;s localStorage only and never sent to our servers.</p>
 
       <h2>Deletion</h2>
       <p>You can delete your sessions and data from within the app. To request full account deletion, email <a href="mailto:oliver@newth.ai">oliver@newth.ai</a>.</p>
@@ -76,23 +60,22 @@ function PrivacyContent() {
 function TermsContent() {
   return (
     <>
-      <h1 className="legal-title">Terms of Service</h1>
       <p className="legal-date">Last updated: March 19, 2026</p>
 
       <h2>What this is</h2>
-      <p>Collab is a collaborative writing tool where AI agents edit documents alongside humans. It is provided as-is for personal and professional use.</p>
+      <p>Markup is a writing surface where AI agents for engineering, product, legal, and design read your docs and push back on what you missed. It is provided as-is for personal and professional use.</p>
 
       <h2>Your content</h2>
-      <p>You own everything you write. We don't claim any rights to your documents or messages. Content you create may be processed by the Google Gemini API to generate AI responses.</p>
+      <p>You own everything you write. We don&apos;t claim any rights to your documents or messages. Content you create may be processed by the Google Gemini API to generate AI responses.</p>
 
       <h2>Acceptable use</h2>
-      <p>Don't use Collab to generate harmful, illegal, or abusive content. Don't attempt to exploit the service or its infrastructure.</p>
+      <p>Don&apos;t use Markup to generate harmful, illegal, or abusive content. Don&apos;t attempt to exploit the service or its infrastructure.</p>
 
       <h2>Availability</h2>
-      <p>We aim to keep Collab running but make no uptime guarantees. The service may change or shut down with reasonable notice.</p>
+      <p>We aim to keep Markup running but make no uptime guarantees. The service may change or shut down with reasonable notice.</p>
 
       <h2>Liability</h2>
-      <p>Collab is provided without warranty. We are not liable for data loss, AI-generated content, or service interruptions.</p>
+      <p>Markup is provided without warranty. We are not liable for data loss, AI-generated content, or service interruptions.</p>
 
       <h2>Contact</h2>
       <p><a href="mailto:oliver@newth.ai">oliver@newth.ai</a></p>


### PR DESCRIPTION
Refinery merge for mk-wisp-wx3 (worker: furiosa, source: mk-rz9). Wraps LegalPage in MarketingLayout + supporting CSS. Refinery note: rebased conflict in ChangelogPage.tsx — kept dementus/mk-05l timeline-feed design (already merged via #303) and dropped furiosa's alternate Streamdown rewrite for that file. LegalPage portion of the commit preserved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
