### PR TITLE
fix(routing): catch-all SPA rewrite for vercel.json (mk-ejv)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,6 @@
 {
   "rewrites": [
-    { "source": "/s/:path*", "destination": "/index.html" },
-    { "source": "/share/:path*", "destination": "/index.html" },
-    { "source": "/privacy", "destination": "/index.html" },
-    { "source": "/terms", "destination": "/index.html" },
-    { "source": "/changelog", "destination": "/index.html" },
-    { "source": "/features", "destination": "/index.html" },
-    { "source": "/pricing", "destination": "/index.html" },
-    { "source": "/about", "destination": "/index.html" },
-    { "source": "/use-cases", "destination": "/index.html" },
-    { "source": "/agents", "destination": "/index.html" },
-    { "source": "/login", "destination": "/index.html" },
-    { "source": "/referrals", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Refinery merge for mk-wisp-knq (worker: capable, source: mk-ejv). Replaces 12 explicit per-route rewrites in vercel.json with a single catch-all. Vercel static serving takes priority so assets/fonts are unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/n3wth/markup/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
